### PR TITLE
fix: unblock the CI formatting check and honor forced readiness refresh on coarse clocks

### DIFF
--- a/artemis/core/diagnostics/engine.py
+++ b/artemis/core/diagnostics/engine.py
@@ -70,6 +70,7 @@ class ReadinessEngine:
         self._report_cache: SystemReadinessReport | None = None
         self._report_cache_time = 0.0
         self._report_cache_generation = -1
+        self._report_publish_seq = 0
         self._cache_generation = 0
         self._report_lock = asyncio.Lock()
 
@@ -144,7 +145,7 @@ class ReadinessEngine:
         device check.
         """
         cacheable = categories is None
-        request_started = time.monotonic()
+        publishes_before_wait = self._report_publish_seq
         if cacheable and not force_refresh:
             cached = self._cached_report(self._REPORT_CACHE_TTL_SECONDS)
             if cached is not None:
@@ -153,7 +154,11 @@ class ReadinessEngine:
         async with self._report_lock:
             # A refresh that completed while this caller waited satisfies even a
             # forced request that began before it, coalescing concurrent clicks.
-            if cacheable and self._report_cache_time >= request_started:
+            # Counting publications instead of comparing clock readings keeps this
+            # exact on Windows, where time.monotonic() advances in 15.625 ms steps
+            # and a report published just before the caller arrived shares its
+            # timestamp, which would swallow the forced rescan.
+            if cacheable and self._report_publish_seq != publishes_before_wait:
                 cached = self._cached_report(float("inf"))
                 if cached is not None:
                     return cached
@@ -175,6 +180,7 @@ class ReadinessEngine:
                 self._report_cache = report.model_copy(deep=True)
                 self._report_cache_time = time.monotonic()
                 self._report_cache_generation = build_generation
+                self._report_publish_seq += 1
             return report
 
     async def _build_report(

--- a/docs/assets/generate_banner.py
+++ b/docs/assets/generate_banner.py
@@ -163,16 +163,27 @@ def generate_banner(
     center_x = px + iw / 2.0
     center_y = py + ih / 2.0
     print(f"Banner successfully generated: {output_path} ({cw}x{ch})")
-    print(f"Ink dimensions: {iw}x{ih}px, Exact center: ({center_x:.1f}, {center_y:.1f}) [Canvas center: ({cw/2:.1f}, {ch/2:.1f}), Offset X: {offset_x:+d}px]")
+    print(
+        f"Ink dimensions: {iw}x{ih}px, Exact center: ({center_x:.1f}, {center_y:.1f}) [Canvas center: ({cw / 2:.1f}, {ch / 2:.1f}), Offset X: {offset_x:+d}px]"
+    )
 
 
 if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser(description="ARTEMIS Official Banner Generator")
-    parser.add_argument("--offset-x", type=int, default=160, help="Horizontal pixel offset to the right from mathematical center (default: 160)")
-    parser.add_argument("--tracking", type=int, default=64, help="Character tracking spacing (default: 64)")
-    parser.add_argument("--font-size", type=int, default=98, help="Font size in pixels (default: 98)")
+    parser.add_argument(
+        "--offset-x",
+        type=int,
+        default=160,
+        help="Horizontal pixel offset to the right from mathematical center (default: 160)",
+    )
+    parser.add_argument(
+        "--tracking", type=int, default=64, help="Character tracking spacing (default: 64)"
+    )
+    parser.add_argument(
+        "--font-size", type=int, default=98, help="Font size in pixels (default: 98)"
+    )
     args = parser.parse_args()
 
     assets_dir = os.path.dirname(os.path.abspath(__file__))

--- a/tests/unit/core/test_diagnostics.py
+++ b/tests/unit/core/test_diagnostics.py
@@ -225,6 +225,37 @@ async def test_readiness_engine_reuses_cache_until_forced():
 
 
 @pytest.mark.asyncio
+async def test_forced_refresh_rescans_when_clock_resolution_is_coarse(monkeypatch):
+    """A forced refresh must rescan even when it starts inside the tick that
+    published the cached report.
+
+    ``time.monotonic()`` advances in 15.625 ms steps on Windows
+    (``GetTickCount64``), so a report published moments earlier carries the same
+    reading as a forced request that follows it. Coalescing must not mistake that
+    earlier report for one that completed while this caller waited on the lock.
+    """
+    engine = ReadinessEngine()
+    result = ProbeResult(
+        id="test_probe",
+        category=ProbeCategory.RUNTIME,
+        title="Test",
+        status=ProbeStatus.PASS,
+        is_blocker=True,
+        summary="Ready",
+        description="Ready",
+    )
+    probe = Mock()
+    probe.probe = AsyncMock(return_value=result)
+    engine._probes = {"test_probe": probe}
+    monkeypatch.setattr("artemis.core.diagnostics.engine.time.monotonic", lambda: 15616.656)
+
+    await engine.run_all()
+    await engine.run_all(force_refresh=True)
+
+    assert probe.probe.await_count == 2
+
+
+@pytest.mark.asyncio
 async def test_invalidation_prevents_in_flight_report_from_becoming_shared_cache():
     engine = ReadinessEngine()
     result = ProbeResult(


### PR DESCRIPTION
## Summary

Two fixes. The first is what turns CI green again, and it is also the reason the second went unnoticed.

### 1. The `ruff format` check fails on `main`

`docs/assets/generate_banner.py` is committed unformatted, so `uv run ruff format --check .` exits 1 on a clean checkout. The **Check Python formatting** step therefore fails on every push and every pull request, on both `ubuntu-latest` and `windows-latest`. The recent runs on `main` are red for this reason alone, which also means any new pull request starts with a red check that has nothing to do with its own contents.

The first commit is the unmodified output of `uv run ruff format`. No logic changes.

### 2. `ReadinessEngine.run_all(force_refresh=True)` can silently return the cached report

The lock-side coalescing branch decided whether a refresh had completed while the caller waited by comparing two `time.monotonic()` readings:

```python
request_started = time.monotonic()
...
async with self._report_lock:
    if cacheable and self._report_cache_time >= request_started:
```

On Windows, `time.monotonic()` is `GetTickCount64()`, whose resolution is 15.625 ms:

```
>>> time.get_clock_info("monotonic")
namespace(implementation='GetTickCount64()', monotonic=True, adjustable=False, resolution=0.015625)
>>> len({time.monotonic() for _ in range(200_000)})
1
```

A report published in the same tick that a forced request begins carries an identical timestamp, so `>=` treats an *earlier* report as one that landed *while* the caller waited. The forced request is answered from cache and no probe runs. `artemis doctor`, the console readiness wizard and `mobile_diagnose` can all reuse a stale snapshot as a result.

This commit counts published reports instead of comparing clock readings. The engine already tracks an invalidation generation, so a publication counter fits the existing idiom, states the intent directly, and is exact on every platform regardless of clock resolution. The coalescing behaviour described in the surrounding comment is preserved: a report published while a caller waits on the lock still satisfies that caller, forced or not.

## Testing

`tests/unit/core/test_diagnostics.py::test_readiness_engine_reuses_cache_until_forced` already covers this and fails on Windows today:

```
tests/unit/core/test_diagnostics.py:222: in test_readiness_engine_reuses_cache_until_forced
    assert probe.probe.await_count == 2
E   AssertionError: assert 1 == 2
```

It passes on Linux only because the clock there is fine-grained, so a regression that reintroduces the timestamp comparison would go unnoticed on a Linux-only run. I added `test_forced_refresh_rescans_when_clock_resolution_is_coarse`, which freezes the clock so the same-tick case is deterministic on every runner. It fails on `main` and passes here.

Verified on Windows 11 with Python 3.12 and the locked environment:

| Step | Exit code |
| --- | --- |
| `uv run ruff format --check .` | 0 |
| `uv run ruff check .` | 0 |
| `uv run python scripts/quality_ratchet.py` | 0 |
| `uv run pyright --project pyright-core.json` | 0 |

`uv run pytest tests/unit tests/tools packages/artemis-client/tests` goes from 2 failures to 1: **2075 passed, 1 failed**.

## The remaining failure, which this pull request deliberately leaves alone

`tests/unit/mcp/test_adb_server_contract.py::test_adb_server_manifest_matches_fixture` still fails. Six of the thirteen pinned tool descriptions differ from the generated ones by docstring indentation, because FastMCP passes `fn.__doc__` through verbatim while the fixture stores the dedented text.

This is not recent drift: the docstrings were already indented in a4c2886, the commit that introduced the fixture, and no `mcp` release in the supported range (1.26 through 1.29) dedents them. The test has never passed.

There are two opposite ways to resolve it, and the choice belongs to the maintainers, since external MCP clients read these descriptions directly:

1. Regenerate the fixture, accepting the raw indentation on the wire.
2. Clean the descriptions at the source so the shipped surface matches the intent the fixture already encodes.

I left it out rather than pick one. Happy to send whichever you prefer as a follow-up.

## Why these failures are invisible today

The **Run deterministic Python tests** step in `.github/workflows/ci.yml` is guarded by `if: github.event_name == 'workflow_dispatch'`, so pull requests never run the suite. Both failures above predate this branch and neither one was surfaced by CI.
