### PR TITLE
fix(mcp): don't misclassify a successful Pro task whose output has a `status` key

### DIFF
--- a/mcp_server/background/task_runner.py
+++ b/mcp_server/background/task_runner.py
@@ -264,7 +264,12 @@ async def run_task(
 
         device_info_line = f"Device Serial: `{target_serial}`\n" if target_serial else ""
 
-        if isinstance(result, dict) and "status" in result and result.get("status") != "completed":
+        if (
+            model.lower() == "flash"
+            and isinstance(result, dict)
+            and "status" in result
+            and result.get("status") != "completed"
+        ):
             error_explanation = result.get("explanation", "Task execution returned failed status.")
             print(f"Task finished with non-completed status: {error_explanation}", file=sys.stderr)
             trace_store.update_trace_status(

--- a/tests/unit/mcp/test_background_task_runner.py
+++ b/tests/unit/mcp/test_background_task_runner.py
@@ -102,3 +102,86 @@ async def test_run_task_applies_pro_tuning_to_agent_config(
         fake_builder.with_explorer.assert_called_once_with(pro_mode=expect_mode)
     fake_agent.run_task.assert_awaited_once()
     assert trace_store.read_status(trace_id)["status"] == "completed"
+
+
+async def _run_pro_task_with_result(tmp_path, monkeypatch, run_result, *, model="Pro"):
+    """Runs the detached background runner with a mocked agent that returns
+    ``run_result`` from ``run_task`` and returns the recorded trace status plus
+    the ``notify`` event_type."""
+    from types import SimpleNamespace
+    from unittest.mock import patch
+
+    from artemis.runtime import trace_store
+    from mcp_server.background import task_runner as bg
+
+    monkeypatch.setattr(trace_store, "TRACES_DIR", str(tmp_path))
+    trace_id = f"trace-{model}-result"
+    trace_store.init_trace(
+        trace_id=trace_id,
+        task_desc="Report order status",
+        model=model,
+        conversation_id="",
+        device_serial="emulator-5554",
+    )
+
+    fake_builder = MagicMock()
+    fake_builders = MagicMock()
+    fake_builders.AgentConfig.with_default_profile.return_value = fake_builder
+    fake_agent = MagicMock()
+    fake_agent._device_context = SimpleNamespace(device_id="emulator-5554")
+    fake_agent.run_task = AsyncMock(return_value=run_result)
+    fake_agent.clean = AsyncMock()
+
+    notify_mock = MagicMock()
+    monkeypatch.setattr(bg.device_utils, "resolve_adb_path", lambda: "adb")
+    monkeypatch.setattr(bg.device_utils, "get_connected_devices", lambda _adb: ["emulator-5554"])
+    monkeypatch.setattr(bg, "resolve_profile_file", lambda: None)
+    monkeypatch.setattr(bg, "_initialize_agent", AsyncMock())
+    monkeypatch.setattr(bg, "notify", notify_mock)
+
+    with (
+        patch("artemis.sdk.builders.Builders", fake_builders),
+        patch("artemis.sdk.Agent", return_value=fake_agent),
+        patch("artemis.sdk.types.AgentProfile", MagicMock()),
+        patch("artemis.config.initialize_llm_config", return_value=MagicMock()),
+    ):
+        await bg.run_task(
+            trace_id=trace_id,
+            task_desc="Report order status",
+            model=model,
+            conversation_id="",
+            device_serial="emulator-5554",
+        )
+
+    event_type = notify_mock.call_args.kwargs["event_type"] if notify_mock.call_args else None
+    return trace_store.read_status(trace_id)["status"], event_type
+
+
+@pytest.mark.asyncio
+async def test_pro_dict_output_with_status_key_is_not_misclassified_as_failed(
+    tmp_path, monkeypatch
+):
+    """A successful Pro task whose output dict carries a domain ``status`` key
+    (e.g. a monitoring/health report) must be recorded as completed, not failed.
+    The ``status != "completed"`` check is for Flash's report envelope, not for
+    a Pro output dict where ``status`` is user data."""
+    status, event_type = await _run_pro_task_with_result(
+        tmp_path, monkeypatch, {"status": "shipped", "order_id": 42}
+    )
+    assert status == "completed"
+    assert event_type == "completed"
+
+
+@pytest.mark.asyncio
+async def test_flash_report_envelope_failure_still_marks_failed(tmp_path, monkeypatch):
+    """Flash's report envelope ``{"status": "failed", "explanation": ...}`` must
+    still be recorded as failed — the fix only stops Pro output dicts from being
+    reinterpreted, it must not weaken Flash's own failure signalling."""
+    status, event_type = await _run_pro_task_with_result(
+        tmp_path,
+        monkeypatch,
+        {"status": "failed", "explanation": "could not complete"},
+        model="flash",
+    )
+    assert status == "failed"
+    assert event_type == "failed"


### PR DESCRIPTION
## Problem

The detached background runner (`mcp_server/background/task_runner.py`) marks a task as **failed** whenever `agent.run_task` returns a dict whose top-level `status` is not `"completed"`:

```python
if isinstance(result, dict) and "status" in result and result.get("status") != "completed":
    error_explanation = result.get("explanation", "Task execution returned failed status.")
    trace_store.update_trace_status(trace_id, "failed", ...)
    notify(..., event_type="failed")
```

That check is written for **Flash**'s report envelope — `{"status": "completed" | "failed", "explanation": ...}` (see `artemis/agents/flash/runner.py`, and the sibling `result.get("explanation")` read on the next line). But a **Pro** task run with an output description returns a *user-shaped* output dict, where `status` is domain data, not a completion signal.

So an ordinary successful Pro result like a monitoring/health report —

```python
{"status": "shipped", "order_id": 42}
```

— is recorded as `failed`, its real result is discarded into an "Incomplete" message, and the caller gets a `failed` wakeup notification. Values such as `"active"`, `"ok"`, `"success"`, `"delivered"` trip it the same way. (A plain string result, or a dict without a `status` key, is correctly reported completed — which is why the existing test, returning `"done"`, didn't catch this.)

## Fix

Gate the report-envelope check on the flash profile, matching the flash/non-flash branching the rest of the function already uses (e.g. the `if not result:` default block just below). A Pro output dict's `status` is no longer reinterpreted as the task's completion status; genuine Pro failures continue to surface as exceptions through the surrounding `try/except`.

```python
if (
    model.lower() == "flash"
    and isinstance(result, dict)
    and "status" in result
    and result.get("status") != "completed"
):
```

## Tests

Added two regression tests to `tests/unit/mcp/test_background_task_runner.py` (deterministic, `make test`):

- a Pro output dict carrying a `status` key (`{"status": "shipped", ...}`) is recorded **completed** with a `completed` notification — this fails on `main` (`assert 'failed' == 'completed'`) and passes with the fix;
- Flash's `{"status": "failed", "explanation": ...}` envelope is still recorded **failed** — proving the change doesn't weaken Flash's own failure signalling.

`make test` (the touched suite), `ruff format --check`, `ruff check`, and `quality_ratchet.py` are clean; `pyright --project pyright-core.json` reports no new diagnostic (the one pre-existing error at `task_runner.py:220` is unrelated to this change).