### PR TITLE
test(flash): mock VisualStepSummarizer in test_turn_index_snapshot for offline execution

### DIFF
--- a/tests/unit/agents/flash/test_turn_index_snapshot.py
+++ b/tests/unit/agents/flash/test_turn_index_snapshot.py
@@ -100,7 +100,10 @@ def mock_context():
 
 
 def _runner(mock_context, observations):
-    with patch("artemis.controllers.unified_controller.get_driver"):
+    with (
+        patch("artemis.controllers.unified_controller.get_driver"),
+        patch("artemis.agents.flash.runner.VisualStepSummarizer"),
+    ):
         runner = FlashRunner(mock_context, goal="Open Wi-Fi and Display")
     runner.summarizer = None
     runner.executor._session = _FakeSession(observations)


### PR DESCRIPTION
Patches `VisualStepSummarizer` in `_runner` within `tests/unit/agents/flash/test_turn_index_snapshot.py`.

`FlashRunner.__init__` instantiates `VisualStepSummarizer`, which attempts to construct `ChatGoogleGenerativeAI` without a mock. In environments without `GOOGLE_API_KEY`, this caused 4 tests to fail with a Pydantic validation error despite `runner.summarizer` being discarded immediately after initialization.

Closes #31.