### PR TITLE
fix(llm): safely extract provider and model in _resolve_endpoint

### DIFF
--- a/artemis/services/llm.py
+++ b/artemis/services/llm.py
@@ -1061,8 +1061,8 @@ def _resolve_endpoint(
         val = getattr(obj, attr, None)
         return val if isinstance(val, expected_type) else None
 
-    provider_val = getattr(cfg, "provider", "google")
-    model_val = getattr(cfg, "model", "gemini-2.5-flash")
+    provider_val = _get_val(cfg, "provider", str) or "google"
+    model_val = _get_val(cfg, "model", str) or "gemini-2.5-flash"
 
     return ModelEndpoint(
         provider=ModelProvider.from_string(provider_val),

--- a/tests/unit/test_llm_gateway.py
+++ b/tests/unit/test_llm_gateway.py
@@ -239,3 +239,17 @@ async def test_mid_stream_failure_records_stream_reset_payload(monkeypatch):
     assert payload["reason"] == "mid_stream_failure"
     assert "stream_exec_id" in payload
     assert "lower API priority" in payload["message"]
+
+
+def test_resolve_endpoint_falls_back_when_provider_or_model_is_not_string():
+    from unittest.mock import MagicMock
+    from artemis.llm.router import ModelProvider
+
+    ctx = MagicMock()
+    # Mock an agent config where provider and model return MagicMocks (non-strings)
+    mock_agent_cfg = MagicMock()
+    ctx.llm_config.get_agent.return_value = mock_agent_cfg
+
+    ep = llm_service._resolve_endpoint(ctx, "operator")
+    assert ep.provider == ModelProvider.GOOGLE
+    assert ep.model_name == "gemini-2.5-flash"


### PR DESCRIPTION
Uses `_get_val(cfg, "provider", str) or "google"` and `_get_val(cfg, "model", str) or "gemini-2.5-flash"` in `artemis.services.llm._resolve_endpoint`, matching the type validation pattern already used for other endpoint fields.

Previously, accessing `provider` via bare `getattr(cfg, "provider", "google")` caused `ModelProvider.from_string` to raise a `ValueError` whenever `cfg` provided non-string or mock attributes (e.g. in `tests/unit/agents/test_explorer.py`).

Adds unit test `test_resolve_endpoint_falls_back_when_provider_or_model_is_not_string` in `tests/unit/test_llm_gateway.py`.

Closes #33.