### PR TITLE
fix(tests): mock VisualStepSummarizer in test_turn_index_snapshot

### DIFF
--- a/tests/unit/agents/flash/test_turn_index_snapshot.py
+++ b/tests/unit/agents/flash/test_turn_index_snapshot.py
@@ -100,7 +100,10 @@ def mock_context():
 
 
 def _runner(mock_context, observations):
-    with patch("artemis.controllers.unified_controller.get_driver"):
+    with (
+        patch("artemis.controllers.unified_controller.get_driver"),
+        patch("artemis.agents.flash.runner.VisualStepSummarizer"),
+    ):
         runner = FlashRunner(mock_context, goal="Open Wi-Fi and Display")
     runner.summarizer = None
     runner.executor._session = _FakeSession(observations)


### PR DESCRIPTION
Fixes #31

### Summary
Running `tests/unit/agents/flash/test_turn_index_snapshot.py` without `GOOGLE_API_KEY` set caused tests to fail during `FlashRunner` initialization because `VisualStepSummarizer` attempts to create a `ChatGoogleGenerativeAI` instance.

Since the test fixture immediately discards the summarizer (`runner.summarizer = None`), attempting to initialize Gemini API clients is unnecessary and breaks offline test runs.

### Proposed Changes
- Patched `artemis.agents.flash.runner.VisualStepSummarizer` inside the `_runner` test fixture in `tests/unit/agents/flash/test_turn_index_snapshot.py`.

### Verification
- Executed `uv run pytest tests/unit/agents/flash/test_turn_index_snapshot.py` and confirmed all 5 unit tests pass deterministically without needing `GOOGLE_API_KEY`.
