### PR TITLE
fix(api): prevent false-like values from stopping all tasks

### DIFF
--- a/apps/admin_console/routers/tasks.py
+++ b/apps/admin_console/routers/tasks.py
@@ -42,6 +42,21 @@ except ImportError:
 router = APIRouter(tags=["tasks"])
 
 
+def _parse_boolean_body_field(value: Any, field_name: str) -> bool:
+    """Parse a JSON boolean without treating every non-empty string as true."""
+    if isinstance(value, bool):
+        return value
+    if value in (0, 1):
+        return bool(value)
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"true", "1", "yes", "on"}:
+            return True
+        if normalized in {"false", "0", "no", "off"}:
+            return False
+    raise HTTPException(status_code=422, detail=f"'{field_name}' must be a boolean")
+
+
 @router.get("/api/tasks/presets")
 async def get_task_presets(
     category: str = "recommended",
@@ -219,7 +234,7 @@ async def stop_task(
         body = await request.json()
         if isinstance(body, dict):
             if "all" in body:
-                target_all = bool(body["all"]) or target_all
+                target_all = _parse_boolean_body_field(body["all"], "all") or target_all
             if body.get("session_id"):
                 target_sid = str(body["session_id"])
             if body.get("device_id"):

--- a/tests/unit/admin_console/test_task_stop_endpoint.py
+++ b/tests/unit/admin_console/test_task_stop_endpoint.py
@@ -1,0 +1,63 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import AsyncMock, MagicMock
+
+from fastapi import HTTPException
+import pytest
+
+from apps.admin_console.routers import tasks
+
+
+@pytest.mark.asyncio
+async def test_stop_task_string_false_does_not_clear_all(monkeypatch):
+    request = AsyncMock()
+    request.json.return_value = {"all": "false", "session_id": "session-1"}
+    stop_tasks = MagicMock(return_value=True)
+    monkeypatch.setattr(tasks.task_queue_service, "stop_tasks", stop_tasks)
+
+    result = await tasks.stop_task(request)
+
+    assert result == {"status": "stopped", "session_id": "session-1"}
+    stop_tasks.assert_called_once_with(
+        clear_all=False,
+        session_id="session-1",
+        device_id=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_stop_task_string_true_clears_all(monkeypatch):
+    request = AsyncMock()
+    request.json.return_value = {"all": "true"}
+    stop_tasks = MagicMock(return_value=True)
+    monkeypatch.setattr(tasks.task_queue_service, "stop_tasks", stop_tasks)
+
+    await tasks.stop_task(request)
+
+    stop_tasks.assert_called_once_with(clear_all=True, session_id=None, device_id=None)
+
+
+@pytest.mark.asyncio
+async def test_stop_task_rejects_unrecognized_boolean(monkeypatch):
+    request = AsyncMock()
+    request.json.return_value = {"all": "not-a-boolean"}
+    stop_tasks = MagicMock(return_value=True)
+    monkeypatch.setattr(tasks.task_queue_service, "stop_tasks", stop_tasks)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await tasks.stop_task(request)
+
+    assert exc_info.value.status_code == 422
+    stop_tasks.assert_not_called()


### PR DESCRIPTION
## Summary

- normalize the `/api/stop` JSON body's `all` value instead of relying on Python truthiness
- preserve explicit query-string `all=true` precedence
- reject unrecognized boolean values before invoking task cancellation
- add router-level regression coverage for false-like, true-like, and invalid values

Closes #36

## Testing

- `uv run pytest tests/unit/admin_console/test_task_stop_endpoint.py tests/unit/admin_console/test_task_queue_service.py -q` — 36 passed, 1 skipped
- `uv run ruff check apps/admin_console/routers/tasks.py tests/unit/admin_console/test_task_stop_endpoint.py`
- `uv run ruff format --check apps/admin_console/routers/tasks.py tests/unit/admin_console/test_task_stop_endpoint.py`
- `make test` — new tests pass; full suite remains red with 82 unrelated failures already present on `main`, primarily missing Gemini credentials and mocked LLM configuration failures