### PR TITLE
fix(tests): isolate Flash model clients and MCP spawn watchdogs

### DIFF
--- a/tests/unit/agents/test_flash_runner.py
+++ b/tests/unit/agents/test_flash_runner.py
@@ -29,6 +29,18 @@ from artemis.agents.validator.tool_declarations import (
 from artemis.context import ArtemisContext
 
 
+@pytest.fixture(autouse=True)
+def isolate_summarizer_model(monkeypatch):
+    """Keep real summarizer behavior without constructing a provider client."""
+    model = Mock()
+    model.ainvoke = AsyncMock(
+        side_effect=AssertionError("Configure a model response before invoking the summarizer")
+    )
+    factory = Mock(return_value=model)
+    monkeypatch.setattr("artemis.agents.flash.summarizer.get_llm", factory)
+    monkeypatch.setattr("artemis.agents.flash.summarizer.get_google_llm", factory)
+
+
 @pytest.fixture
 def mock_context():
     ctx = Mock(spec=ArtemisContext)

--- a/tests/unit/agents/test_flash_runner_ledger.py
+++ b/tests/unit/agents/test_flash_runner_ledger.py
@@ -56,6 +56,18 @@ FAILED_RESULT_RE = re.compile(
 )
 
 
+@pytest.fixture(autouse=True)
+def isolate_summarizer_model(monkeypatch):
+    """Keep real summarizer behavior without constructing a provider client."""
+    model = Mock()
+    model.ainvoke = AsyncMock(
+        side_effect=AssertionError("Configure a model response before invoking the summarizer")
+    )
+    factory = Mock(return_value=model)
+    monkeypatch.setattr("artemis.agents.flash.summarizer.get_llm", factory)
+    monkeypatch.setattr("artemis.agents.flash.summarizer.get_google_llm", factory)
+
+
 @pytest.fixture
 def mock_context():
     ctx = Mock(spec=ArtemisContext)

--- a/tests/unit/agents/test_flash_scrub_edge.py
+++ b/tests/unit/agents/test_flash_scrub_edge.py
@@ -20,7 +20,7 @@ content after both cleanup passes.
 """
 
 import json
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
@@ -28,6 +28,18 @@ from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from artemis.agents.flash.context_compressor import ScrubEdgeCompressor
 from artemis.agents.flash.summarizer import VisualStepSummarizer
 from artemis.context import ArtemisContext
+
+
+@pytest.fixture(autouse=True)
+def isolate_summarizer_model(monkeypatch):
+    """Keep real summarizer behavior without constructing a provider client."""
+    model = Mock()
+    model.ainvoke = AsyncMock(
+        side_effect=AssertionError("Configure a model response before invoking the summarizer")
+    )
+    factory = Mock(return_value=model)
+    monkeypatch.setattr("artemis.agents.flash.summarizer.get_llm", factory)
+    monkeypatch.setattr("artemis.agents.flash.summarizer.get_google_llm", factory)
 
 
 @pytest.fixture

--- a/tests/unit/agents/test_flash_step_summarizer.py
+++ b/tests/unit/agents/test_flash_step_summarizer.py
@@ -31,6 +31,18 @@ from artemis.context import ArtemisContext
 from artemis.sdk.builders import Builders
 
 
+@pytest.fixture(autouse=True)
+def isolate_summarizer_model(monkeypatch):
+    """Keep real summarizer behavior without constructing a provider client."""
+    model = Mock()
+    model.ainvoke = AsyncMock(
+        side_effect=AssertionError("Configure a model response before invoking the summarizer")
+    )
+    factory = Mock(return_value=model)
+    monkeypatch.setattr("artemis.agents.flash.summarizer.get_llm", factory)
+    monkeypatch.setattr("artemis.agents.flash.summarizer.get_google_llm", factory)
+
+
 @pytest.fixture
 def mock_context():
     ctx = Mock(spec=ArtemisContext)
@@ -834,13 +846,14 @@ def test_build_focus_context_drops_blank_fields_and_caps_reasoning_tail_intact()
 
 def test_flash_config_and_builder():
     """Verify Flash profile configuration model and SDK builder fluent API."""
+    # This checks configuration values, not external provider credentials.
     cfg = Builders.AgentConfig.with_flash_config(
         max_turns=25,
         explorer_mode="flash",
         step_summarizer=True,
         step_summarizer_model="gemini-2.5-flash-lite",
         prune_history_xml=True,
-    ).build()
+    ).build(validate_profiles=False)
 
     assert cfg.flash.max_turns == 25
     assert cfg.flash.explorer_mode == "flash"

--- a/tests/unit/mcp/test_mcp_tools.py
+++ b/tests/unit/mcp/test_mcp_tools.py
@@ -18,6 +18,7 @@ import inspect
 import json
 import os
 import shutil
+import sqlite3
 import tempfile
 from types import SimpleNamespace
 import uuid
@@ -386,7 +387,9 @@ async def test_mobile_get_device_state_hierarchy_without_ocr():
 
 
 @pytest.mark.asyncio
-async def test_mobile_inspect_trace_invalid_action():
+async def test_mobile_inspect_trace_invalid_action(temp_trace_env):
+    # The database precondition must not depend on a previous local task run.
+    sqlite3.connect(os.path.join(temp_trace_env, "data_engine.db")).close()
     res = await mobile_inspect_trace(action="invalid_action", trace_id="trace-123")
     assert "error" in res
     assert "not supported" in res["message"]

--- a/tests/unit/mcp/test_mcp_tools.py
+++ b/tests/unit/mcp/test_mcp_tools.py
@@ -34,6 +34,14 @@ from mcp_server.tools import (
 from artemis.runtime import trace_store
 
 
+@pytest.fixture(autouse=True)
+def mock_spawn_watchdog(monkeypatch):
+    """Fake runner processes must not leave live watchdogs after fixture teardown."""
+    watchdog = MagicMock()
+    monkeypatch.setattr("mcp_server.tools.task_runner._start_spawn_watchdog", watchdog)
+    return watchdog
+
+
 @pytest.fixture
 def temp_trace_env(monkeypatch):
     temp_dir = tempfile.mkdtemp()
@@ -88,7 +96,9 @@ def test_mobile_run_task_invalid_model():
         mobile_run_task(task_desc="test", conversation_id="conv-1", model="invalid_model")
 
 
-def test_mobile_run_task_reserves_and_passes_global_queue_ticket(temp_trace_env):
+def test_mobile_run_task_reserves_and_passes_global_queue_ticket(
+    temp_trace_env, mock_spawn_watchdog
+):
     process = MagicMock(pid=43210)
     with (
         patch(
@@ -117,11 +127,14 @@ def test_mobile_run_task_reserves_and_passes_global_queue_ticket(temp_trace_env)
     assert popen.call_args.kwargs["env"]["ARTEMIS_DEVICE_QUEUE_TICKET"] == "queue-ticket-1"
     assert popen.call_args.kwargs["env"]["ARTEMIS_TASK_INGRESS"] == "mcp"
     status = trace_store.read_status(result["trace_id"])
+    mock_spawn_watchdog.assert_called_once_with(
+        result["trace_id"], 43210, "queue-ticket-1", "conv-1"
+    )
     assert status["queue_ticket"] == "queue-ticket-1"
     assert status["device_serial"] is None
 
 
-def test_mobile_run_task_with_device_serial(temp_trace_env):
+def test_mobile_run_task_with_device_serial(temp_trace_env, mock_spawn_watchdog):
     process = MagicMock(pid=54321)
     with (
         patch(
@@ -157,6 +170,9 @@ def test_mobile_run_task_with_device_serial(temp_trace_env):
         session_id=result["trace_id"],
         ingress="mcp",
         device_id="pixel-11-pro-001",
+    )
+    mock_spawn_watchdog.assert_called_once_with(
+        result["trace_id"], 54321, "queue-ticket-dev", "conv-2"
     )
     assert result["device_serial"] == "pixel-11-pro-001"
     cmd = popen.call_args.args[0]


### PR DESCRIPTION
## Summary

Several deterministic tests depend on real model clients or local runtime state despite the credential-free test contract in `CONTRIBUTING.md`. This fixes test isolation in four Flash modules and one MCP module, without changing production behavior.

Fixes #41 and #43.

- Patch both model factories at the summarizer module boundary before construction. Keep the real runner, summarizer, retry, ledger, and compression implementations and their assertions. The default async model stub raises on an unconfigured invocation.
- Use the existing `validate_profiles=False` builder option in the configuration-only test.
- Mock the spawn-watchdog launcher for fake MCP subprocesses and assert its dispatch arguments. Previously, four tests left real watchdog threads running after fixture teardown, causing failure notifications for simulated tasks. Dedicated watchdog behavior tests remain active with external effects mocked.
- Create a temporary SQLite database for the invalid-action inspection test, so it does not depend on a database left by earlier local task runs.

The turn-index snapshot file addressed by #32/#35 is unchanged; this covers additional test modules.

## Reproduction and before/after evidence

Environment: Windows, Python 3.12.14, committed lockfile, no Google/Gemini/OpenAI API keys. Baseline: `0860788`. Latest PR head: `cfcfc8d`.

```sh
uv run pytest -q tests/unit/agents/test_flash_runner.py tests/unit/agents/test_flash_runner_ledger.py tests/unit/agents/test_flash_scrub_edge.py tests/unit/agents/test_flash_step_summarizer.py tests/unit/mcp/test_mcp_tools.py tests/unit/mcp/test_spawn_watchdog.py
```

```text
Four Flash modules:
Before: 64 failed, 13 passed
After:  77 passed

MCP watchdog isolation guard:
Before: 25 passed, 4 teardown errors (real watchdog thread-start attempts)
After:  25 passed, no real watchdog thread-start attempts
Dedicated watchdog behavior tests: 4 passed

All six target modules in a fresh worktree:
Before the database fixture fix: 1 failed, 105 passed
Latest PR:                      106 passed in 2.18s

Full deterministic suite (pytest -q):
Upstream: 82 failed, 2109 passed, 4 skipped, 8 deselected
Latest PR: 18 failed, 2173 passed, 4 skipped, 8 deselected
Latest full run: 91.00s; 64 baseline failures resolved, no new failed nodes
```

The temporary watchdog guard intercepted thread starts without executing them, avoiding real notifications or process termination during reproduction. The Flash modules also passed with shuffled execution order (seed 42) and a guard forbidding real provider-client construction.

#41 and #43 contain the root-cause analysis and representative failure excerpts. Commands above use the portable `uv run` form; local execution used the locked virtual environment's Python executable in isolated worktrees.

## Contribution checks and limitations

Executed the Windows equivalents of the contribution checks:

- `make test`: results above. The remaining 18 baseline failures include other credential/mock-configuration tests, readiness-cache timing, and the ADB manifest contract. This PR does not claim to resolve them.
- `make lint`: repository formatting, changed-file Ruff, and quality ratchet pass. Repository-wide Ruff retains 11 pre-existing playground errors tracked by #29/#30.
- `make typecheck`: protected-core Pyright reports 0 errors and 0 warnings.
- `git diff --check`: passes.

No tests are skipped or removed by this change. During extended testing, an unchanged device FIFO reservation test failed intermittently and could leave pytest running; the same behavior was reproduced on clean upstream. It did not fail in the latest full run and remains an unresolved validation limitation.

Private screenshots, UI XML, and raw device traces are not included. Public evidence consists of sanitized text excerpts.
