### PR TITLE
fix(config): empty or placeholder API keys resolve to None and say so; blank inherited vars no longer shadow .env

### DIFF
--- a/artemis/config/llm.py
+++ b/artemis/config/llm.py
@@ -68,6 +68,38 @@ class CyFunctionDetector(metaclass=_CyFunctionDetectorMeta):
     pass
 
 
+def _credential_hint(primary: str, *aliases: str) -> str:
+    """Build a diagnostic hint for a missing credential (never exposes key material).
+
+    Reports which dotenv file was actually loaded and, for each accepted env var,
+    whether it is unset, present-but-empty, or set — the three cases that look
+    identical when you only read `.env` by eye.
+    """
+    from artemis.config.paths import get_env_file
+    from artemis.config.settings import is_placeholder_key
+
+    def state(var: str) -> str:
+        raw = os.environ.get(var)
+        if raw is None:
+            return f"{var}=<unset>"
+        if not raw.strip() or is_placeholder_key(raw):
+            return f"{var}=<present but empty/placeholder>"
+        return f"{var}=<set>"
+
+    try:
+        env_file = str(get_env_file())
+    except Exception:  # pragma: no cover - defensive
+        env_file = "<unresolved>"
+    names = (primary, *aliases)
+    states = ", ".join(state(v) for v in names)
+    alias_note = f" (accepted aliases: {', '.join(aliases)})" if aliases else ""
+    return (
+        f"{primary}{alias_note}; dotenv loaded from {env_file}; {states}. "
+        "Set a non-empty value there and restart the MCP server / CLI process "
+        "(settings are read once at import)."
+    )
+
+
 class LLM(BaseModel):
     """Base model representing an LLM model provider and runtime parameters."""
 
@@ -85,21 +117,24 @@ class LLM(BaseModel):
         """Ensure the required API key or credentials exist in settings for this provider."""
         if self.provider == "openai":
             if not settings.OPENAI_API_KEY:
-                raise Exception(f"{name} requires OPENAI_API_KEY in .env")
+                raise Exception(f"{name} requires " + _credential_hint("OPENAI_API_KEY"))
         elif self.provider == "google":
             if not settings.GOOGLE_API_KEY:
-                raise Exception(f"{name} requires GOOGLE_API_KEY in .env")
+                raise Exception(
+                    f"{name} requires "
+                    + _credential_hint("GOOGLE_API_KEY", "GEMINI_API_KEY", "GCP_API_KEY")
+                )
         elif self.provider == "vertexai":
             validate_vertex_ai_credentials()
         elif self.provider == "anthropic":
             if not (settings.ANTHROPIC_API_KEY or os.environ.get("ANTHROPIC_API_KEY")):
-                raise Exception(f"{name} requires ANTHROPIC_API_KEY in .env")
+                raise Exception(f"{name} requires " + _credential_hint("ANTHROPIC_API_KEY"))
         elif self.provider == "openrouter":
             if not settings.OPEN_ROUTER_API_KEY:
-                raise Exception(f"{name} requires OPEN_ROUTER_API_KEY in .env")
+                raise Exception(f"{name} requires " + _credential_hint("OPEN_ROUTER_API_KEY"))
         elif self.provider == "xai":
             if not settings.XAI_API_KEY:
-                raise Exception(f"{name} requires XAI_API_KEY in .env")
+                raise Exception(f"{name} requires " + _credential_hint("XAI_API_KEY"))
 
     def __str__(self) -> str:
         return f"{self.provider}/{self.model}"

--- a/artemis/config/settings.py
+++ b/artemis/config/settings.py
@@ -169,7 +169,11 @@ class Settings(BaseSettings):
             "API_KEY",
         ):
             val = getattr(self, attr, None)
-            if val and is_placeholder_key(val):
+            # NOTE: an empty value in .env (e.g. `GOOGLE_API_KEY=`) parses to
+            # SecretStr("") which is falsy, so `if val and ...` skipped it and the
+            # attribute stayed a non-None empty secret. Normalize on `is not None`
+            # so an empty/placeholder credential always becomes None.
+            if val is not None and is_placeholder_key(val):
                 setattr(self, attr, None)
 
         if not self.GOOGLE_API_KEY:

--- a/artemis/config/settings.py
+++ b/artemis/config/settings.py
@@ -46,7 +46,34 @@ from artemis.config.paths import (
 )
 from artemis.utils.logger import get_logger
 
+def _clear_blank_credential_env_vars() -> None:
+    """Drop credential env vars that are present but blank, before .env is loaded.
+
+    `load_dotenv` never overrides a variable that already exists in the process
+    environment. A parent process started with `GOOGLE_API_KEY=` (blank) — e.g.
+    the ARTEMIS daemon launched before the key was filled in — therefore passes
+    that blank down to every child runner, and the child's `.env` value is
+    silently ignored for the lifetime of the parent. A blank value carries no
+    information, so let the dotenv file win.
+    """
+    for _name in (
+        "GOOGLE_API_KEY",
+        "GEMINI_API_KEY",
+        "GCP_API_KEY",
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "XAI_API_KEY",
+        "OPEN_ROUTER_API_KEY",
+        "OCR_API_KEY",
+        "VISION_API_KEY",
+    ):
+        _val = os.environ.get(_name)
+        if _val is not None and not _val.strip():
+            del os.environ[_name]
+
+
 # Installed wheels load .env from the user directory, outside site-packages.
+_clear_blank_credential_env_vars()
 _canonical_env = get_env_file()
 load_dotenv(dotenv_path=_canonical_env, verbose=True)
 _global_env = GLOBAL_APP_DIR / ".env"

--- a/tests/unit/config/test_credential_resolution.py
+++ b/tests/unit/config/test_credential_resolution.py
@@ -1,0 +1,87 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for empty-credential normalization and diagnostics.
+
+Context: a `.env` containing `GOOGLE_API_KEY=` / `GEMINI_API_KEY=` (key names
+present, values empty) produced `Planner requires GOOGLE_API_KEY in .env`, which
+reads as "the variable is missing" and sent debugging down the wrong path.
+"""
+
+import pytest
+from pydantic import SecretStr
+
+from artemis.config.llm import LLM, _credential_hint
+from artemis.config.settings import Settings
+
+
+def test_empty_env_value_normalizes_to_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An empty `KEY=` in the environment must become None, not SecretStr('')."""
+    monkeypatch.setenv("GOOGLE_API_KEY", "")
+    monkeypatch.setenv("GEMINI_API_KEY", "")
+    s = Settings(_env_file=None)  # type: ignore[call-arg]
+    assert s.GOOGLE_API_KEY is None
+    assert s.GEMINI_API_KEY is None
+    assert s.get_api_key("google") is None
+
+
+def test_gemini_key_aliases_to_google_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """GEMINI_API_KEY alone must satisfy the Google provider."""
+    monkeypatch.setenv("GOOGLE_API_KEY", "")
+    monkeypatch.setenv("GEMINI_API_KEY", "test-key-value")
+    s = Settings(_env_file=None)  # type: ignore[call-arg]
+    assert s.GOOGLE_API_KEY is not None
+    assert s.GOOGLE_API_KEY.get_secret_value() == "test-key-value"
+
+
+def test_credential_hint_distinguishes_empty_from_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The hint must say which dotenv was loaded and empty != unset, without leaking values."""
+    monkeypatch.setenv("GOOGLE_API_KEY", "")
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.setenv("GCP_API_KEY", "super-secret-value")
+    hint = _credential_hint("GOOGLE_API_KEY", "GEMINI_API_KEY", "GCP_API_KEY")
+    assert "GOOGLE_API_KEY=<present but empty/placeholder>" in hint
+    assert "GEMINI_API_KEY=<unset>" in hint
+    assert "GCP_API_KEY=<set>" in hint
+    assert "super-secret-value" not in hint
+    assert ".env" in hint
+    assert "restart" in hint.lower()
+
+
+def test_validate_provider_google_error_carries_hint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The planner-facing error must name the alias and the loaded dotenv path."""
+    import artemis.config.llm as llm_mod
+
+    monkeypatch.setattr(llm_mod.settings, "GOOGLE_API_KEY", None)
+    monkeypatch.setenv("GOOGLE_API_KEY", "")
+    model = LLM(provider="google", model="gemini-2.5-flash")
+    with pytest.raises(Exception) as exc:
+        model.validate_provider("Planner")
+    msg = str(exc.value)
+    assert "Planner requires GOOGLE_API_KEY" in msg
+    assert "GEMINI_API_KEY" in msg
+    assert "dotenv loaded from" in msg
+
+
+def test_placeholder_secret_is_dropped(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Placeholder values must not count as credentials."""
+    monkeypatch.setenv("GOOGLE_API_KEY", "your_gemini_api_key_here")
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    s = Settings(_env_file=None)  # type: ignore[call-arg]
+    assert s.GOOGLE_API_KEY is None
+    assert isinstance(SecretStr("x"), SecretStr)

--- a/tests/unit/config/test_credential_resolution.py
+++ b/tests/unit/config/test_credential_resolution.py
@@ -85,3 +85,37 @@ def test_placeholder_secret_is_dropped(monkeypatch: pytest.MonkeyPatch) -> None:
     s = Settings(_env_file=None)  # type: ignore[call-arg]
     assert s.GOOGLE_API_KEY is None
     assert isinstance(SecretStr("x"), SecretStr)
+
+
+def test_blank_inherited_env_var_does_not_shadow_dotenv(tmp_path, monkeypatch) -> None:
+    """A blank inherited `GOOGLE_API_KEY=` must not win over a filled .env.
+
+    `load_dotenv` skips variables already set in the environment, so a parent
+    process launched with blank credentials used to poison every child.
+    """
+    from artemis.config.settings import _clear_blank_credential_env_vars
+    from dotenv import load_dotenv
+
+    env_file = tmp_path / ".env"
+    env_file.write_text("GOOGLE_API_KEY=from-dotenv\n", encoding="utf-8")
+    monkeypatch.setenv("GOOGLE_API_KEY", "")
+    _clear_blank_credential_env_vars()
+    load_dotenv(dotenv_path=env_file)
+    import os as _os
+
+    assert _os.environ["GOOGLE_API_KEY"] == "from-dotenv"
+
+
+def test_nonblank_env_var_still_wins_over_dotenv(tmp_path, monkeypatch) -> None:
+    """A real inherited value must be preserved (dotenv must not override it)."""
+    from artemis.config.settings import _clear_blank_credential_env_vars
+    from dotenv import load_dotenv
+
+    env_file = tmp_path / ".env"
+    env_file.write_text("GOOGLE_API_KEY=from-dotenv\n", encoding="utf-8")
+    monkeypatch.setenv("GOOGLE_API_KEY", "from-parent")
+    _clear_blank_credential_env_vars()
+    load_dotenv(dotenv_path=env_file)
+    import os as _os
+
+    assert _os.environ["GOOGLE_API_KEY"] == "from-parent"


### PR DESCRIPTION
## Problem

`.env.example` ships `GOOGLE_API_KEY=` and `GEMINI_API_KEY=` as blank lines. When a user leaves a value empty (or edits `.env` while the daemon is already running), the planner fails with:

```
Planner requires GOOGLE_API_KEY in .env
```

which says the variable is *missing* when it is present and empty. Three things stack up:

1. `fallback_api_keys` sanitizes placeholders under `if val and is_placeholder_key(val)`. Pydantic's `SecretStr("")` is falsy, so an empty secret skips the check and survives as a non-`None` empty `SecretStr`; the `GEMINI_API_KEY` alias never applies.
2. `validate_provider` raises a bare message that cannot distinguish "unset" from "present but empty/placeholder".
3. `load_dotenv` never overrides a variable already in the environment, blank included. A daemon started with blank vars exports the blanks to every runner it spawns, so a corrected `.env` stays invisible until the whole daemon restarts.

## Fix

- Empty or placeholder credential values normalize to `None`, so the existing alias chain (`GEMINI_API_KEY` → `GOOGLE_API_KEY` → `GCP_API_KEY`) works.
- Blank credential vars inherited from the environment are dropped before the dotenv load; a non-blank inherited value still wins.
- Provider errors name the loaded dotenv path, the accepted aliases, and per-variable `<unset>` vs `<present but empty/placeholder>`. Key material is never printed.

## Tests

`tests/unit/config/test_credential_resolution.py` (7 tests). The core assertion fails on `main`: `Settings(_env_file=None)` with `GOOGLE_API_KEY=""` yields a `SecretStr` on `main` and `None` with this change.

Found while running ARTEMIS from an MCP server whose `.env` had both key lines present and empty; the next task ran past the credential gate on the same, un-restarted daemon after this change.
