### PR TITLE
fix(diagnostics): honour the requested/pinned device serial instead of probing another attached device

### DIFF
--- a/artemis/core/diagnostics/engine.py
+++ b/artemis/core/diagnostics/engine.py
@@ -43,6 +43,7 @@ from artemis.core.diagnostics.schema import (
 from artemis.toolchain import toolchain
 from artemis.platform import platform
 from artemis.utils.logger import get_logger
+from artemis.config.settings import settings
 
 logger = get_logger(__name__)
 
@@ -66,7 +67,12 @@ class ReadinessEngine:
         self._toolchain_probe = ToolchainProbe()
         self._credentials_probe = LLMCredentialsProbe()
         self._ocr_probe = VisionOCRProbe()
-        self._adb_probe = AdbDeviceProbe()
+        # Default the report's device to the configured ADB_DEVICE_SERIAL: without
+        # it, `artemis doctor` (which passes no serial) described whichever device
+        # answered first, which on a multi-device host is not the one the operator
+        # pinned in .env.
+        _configured_serial = (settings.ADB_DEVICE_SERIAL or "").strip() or None
+        self._adb_probe = AdbDeviceProbe(target_serial=_configured_serial)
         self._report_cache: SystemReadinessReport | None = None
         self._report_cache_time = 0.0
         self._report_cache_generation = -1

--- a/artemis/core/diagnostics/probes/adb_probe.py
+++ b/artemis/core/diagnostics/probes/adb_probe.py
@@ -38,6 +38,29 @@ from artemis.utils.logger import get_logger
 logger = get_logger(__name__)
 
 
+def select_active_device(ready_devices: list, target_serial: str | None):
+    """Pick the device a diagnostics report should describe.
+
+    An explicitly requested serial wins unless it is CONFIRMED locked. The rule
+    used to require `is_locked is False`, so a requested device whose lock state
+    came back undetermined (emulators routinely do) silently lost to whichever
+    other attached phone answered first, and the report described a device the
+    caller never asked about.
+    """
+    preferred_dev = None
+    if target_serial:
+        preferred_dev = next((d for d in ready_devices if d.serial == target_serial), None)
+
+    if preferred_dev is not None and preferred_dev.is_locked is not True:
+        return preferred_dev
+
+    unlocked_dev = next((d for d in ready_devices if d.is_locked is False), None)
+    if unlocked_dev:
+        return unlocked_dev
+    unknown_dev = next((d for d in ready_devices if d.is_locked is None), None)
+    return preferred_dev or unknown_dev or ready_devices[0]
+
+
 class AdbDeviceProbe(BaseProbe):
     """Deep inspection probe for Android Debug Bridge, connected mobile devices, and local AVD emulators."""
 
@@ -812,23 +835,7 @@ class AdbDeviceProbe(BaseProbe):
                 )
 
         # 4. Ready device available
-        preferred_dev = None
-        if self._target_serial:
-            preferred_dev = next(
-                (d for d in ready_devices if d.serial == self._target_serial), None
-            )
-
-        if preferred_dev and preferred_dev.is_locked is False:
-            active_dev = preferred_dev
-        else:
-            # Prefer a confirmed unlocked ready device
-            unlocked_dev = next((d for d in ready_devices if d.is_locked is False), None)
-            if unlocked_dev:
-                active_dev = unlocked_dev
-            else:
-                # If no confirmed unlocked device, prefer undetermined lock state over confirmed locked
-                unknown_dev = next((d for d in ready_devices if d.is_locked is None), None)
-                active_dev = preferred_dev or unknown_dev or ready_devices[0]
+        active_dev = select_active_device(ready_devices, self._target_serial)
 
         display_name = active_dev.model or active_dev.serial
         if active_dev.screen_resolution:

--- a/tests/unit/diagnostics/test_active_device_selection.py
+++ b/tests/unit/diagnostics/test_active_device_selection.py
@@ -48,3 +48,22 @@ def test_no_request_prefers_confirmed_unlocked() -> None:
     locked = _Dev("a", True)
     unlocked = _Dev("b", False)
     assert select_active_device([locked, unlocked], None) is unlocked
+
+
+def test_engine_defaults_probe_target_to_configured_serial(monkeypatch) -> None:
+    """`artemis doctor` passes no serial; the pinned ADB_DEVICE_SERIAL must still win."""
+    from artemis.config.settings import settings
+    from artemis.core.diagnostics.engine import ReadinessEngine
+
+    monkeypatch.setattr(settings, "ADB_DEVICE_SERIAL", "emulator-5554")
+    engine = ReadinessEngine()
+    assert engine._adb_probe._target_serial == "emulator-5554"
+
+
+def test_engine_target_is_none_when_unset(monkeypatch) -> None:
+    from artemis.config.settings import settings
+    from artemis.core.diagnostics.engine import ReadinessEngine
+
+    monkeypatch.setattr(settings, "ADB_DEVICE_SERIAL", "   ")
+    engine = ReadinessEngine()
+    assert engine._adb_probe._target_serial is None

--- a/tests/unit/diagnostics/test_active_device_selection.py
+++ b/tests/unit/diagnostics/test_active_device_selection.py
@@ -1,0 +1,50 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The diagnostics report must describe the device the caller asked for."""
+
+from dataclasses import dataclass
+
+from artemis.core.diagnostics.probes.adb_probe import select_active_device
+
+
+@dataclass
+class _Dev:
+    serial: str
+    is_locked: bool | None
+
+
+def test_requested_device_with_unknown_lock_state_still_wins() -> None:
+    """An emulator whose lock state is undetermined must not lose to another phone."""
+    phone = _Dev("4e42463151563398", False)
+    emulator = _Dev("emulator-5554", None)
+    assert select_active_device([phone, emulator], "emulator-5554") is emulator
+
+
+def test_requested_unlocked_device_wins() -> None:
+    phone = _Dev("4e42463151563398", False)
+    emulator = _Dev("emulator-5554", False)
+    assert select_active_device([phone, emulator], "emulator-5554") is emulator
+
+
+def test_confirmed_locked_request_falls_back() -> None:
+    phone = _Dev("4e42463151563398", False)
+    emulator = _Dev("emulator-5554", True)
+    assert select_active_device([phone, emulator], "emulator-5554") is phone
+
+
+def test_no_request_prefers_confirmed_unlocked() -> None:
+    locked = _Dev("a", True)
+    unlocked = _Dev("b", False)
+    assert select_active_device([locked, unlocked], None) is unlocked


### PR DESCRIPTION
## Problem

On a host with more than one Android device attached, `mobile_diagnose(device_serial=...)` and `artemis doctor` can select a device the caller did not ask for:

- The active-device rule required `is_locked is False`. Emulators report an undetermined lock state, so with a physical phone unlocked and an emulator requested, the requested emulator lost and the phone was selected.
- `ReadinessEngine` probed the first device it found instead of the pinned `ADB_DEVICE_SERIAL`.

With `probe_device=true` the report then screenshots and dumps the UI hierarchy of that other device, which matters when the phone belongs to someone else.

## Fix

- The requested serial wins unless it is *confirmed* locked.
- `ReadinessEngine` defaults its probe target to the pinned `ADB_DEVICE_SERIAL`.

## Tests

`tests/unit/diagnostics/test_active_device_selection.py` (6 tests). With the real topology (physical device unlocked, emulator lock state unknown, emulator requested) the old rule picks the physical device and the new rule picks the emulator; `artemis doctor` on that host reports the emulator instead of the phone after this change.
