### PR TITLE
fix(mcp): resolve modern Antigravity config and rules installation paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ PYTHONUNBUFFERED = "1"
 PYTHONPATH = "/path/to/artemis"
 ```
 
-* **Antigravity** (`~/.gemini/jetski/mcp_config.json`):
+* **Antigravity** (`~/.gemini/antigravity/mcp_config.json`):
 ```json
 {
   "mcpServers": {

--- a/README_CN.md
+++ b/README_CN.md
@@ -146,7 +146,7 @@ PYTHONUNBUFFERED = "1"
 PYTHONPATH = "/path/to/artemis"
 ```
 
-* **Antigravity** (`~/.gemini/jetski/mcp_config.json`)：
+* **Antigravity** (`~/.gemini/antigravity/mcp_config.json`)：
 ```json
 {
   "mcpServers": {

--- a/artemis/interfaces/cli/commands/mcp.py
+++ b/artemis/interfaces/cli/commands/mcp.py
@@ -481,10 +481,13 @@ def install_rules(client: str, project_root: str) -> list[str]:
         if target in ("antigravity", "jetski"):
             gemini_md = Path.home() / ".gemini" / "GEMINI.md"
             global_rule = Path.home() / ".gemini" / "rules" / "artemis.md"
+            antigravity_rule = Path.home() / ".gemini" / "antigravity" / "rules" / "artemis.md"
             if _inject_rules_block(gemini_md, raw_rules):
                 installed_paths.append(str(gemini_md))
             if _write_rule_file(global_rule, raw_rules):
                 installed_paths.append(str(global_rule))
+            if _write_rule_file(antigravity_rule, raw_rules):
+                installed_paths.append(str(antigravity_rule))
         elif target == "cursor":
             cursor_rules_file = Path.home() / ".cursorrules"
             global_mdc = Path.home() / ".cursor" / "rules" / "artemis.mdc"
@@ -586,12 +589,12 @@ def install_mcp_config(client: str, python_exe: str, project_root: str) -> list[
                 "mcpServers"
             ]["artemis"]
             jetski_path = Path.home() / ".gemini" / "jetski" / "mcp_config.json"
-            antigravity_legacy_path = Path.home() / ".gemini" / "antigravity" / "mcp_config.json"
+            antigravity_path = Path.home() / ".gemini" / "antigravity" / "mcp_config.json"
             config_path = Path.home() / ".gemini" / "config" / "mcp_config.json"
             if _merge_json_file(jetski_path, "artemis", legacy_server_cfg):
                 installed_paths.append(str(jetski_path))
-            if _merge_json_file(antigravity_legacy_path, "artemis", current_server_cfg):
-                installed_paths.append(str(antigravity_legacy_path))
+            if _merge_json_file(antigravity_path, "artemis", current_server_cfg):
+                installed_paths.append(str(antigravity_path))
             if _merge_json_file(config_path, "artemis", current_server_cfg):
                 installed_paths.append(str(config_path))
         elif target in ("claude", "claude_code", "claude_desktop"):
@@ -780,7 +783,7 @@ def mcp_command(
         client = generate_config.lower()
         if client == "all":
             all_configs = {
-                "antigravity (~/.gemini/jetski/mcp_config.json)": _get_config_snippet(
+                "antigravity (~/.gemini/antigravity/mcp_config.json)": _get_config_snippet(
                     "antigravity", python_exe, project_root
                 ),
                 "cursor (.cursor/mcp.json)": _get_config_snippet(

--- a/artemis/platform/darwin.py
+++ b/artemis/platform/darwin.py
@@ -44,7 +44,11 @@ class DarwinPlatformPaths(IPlatformPaths):
             p.mkdir(parents=True, exist_ok=True)
             return p
 
-        # Check legacy ~/.artemis or ~/.gemini/jetski directory if it exists
+        # Check legacy ~/.gemini/antigravity, ~/.artemis, or ~/.gemini/jetski directory if it exists
+        legacy_antigravity = self._home / ".gemini" / "antigravity"
+        if legacy_antigravity.exists():
+            return legacy_antigravity
+
         legacy_artemis = self._home / ".artemis"
         if legacy_artemis.exists():
             return legacy_artemis

--- a/artemis/platform/linux.py
+++ b/artemis/platform/linux.py
@@ -55,7 +55,11 @@ class LinuxPlatformPaths(IPlatformPaths):
             p.mkdir(parents=True, exist_ok=True)
             return p
 
-        # Check legacy ~/.gemini/jetski or ~/.artemis directory if it exists
+        # Check legacy ~/.gemini/antigravity, ~/.gemini/jetski or ~/.artemis directory if it exists
+        legacy_antigravity = self._home / ".gemini" / "antigravity"
+        if legacy_antigravity.exists():
+            return legacy_antigravity
+
         legacy_jetski = self._home / ".gemini" / "jetski"
         if legacy_jetski.exists():
             return legacy_jetski

--- a/artemis/platform/windows.py
+++ b/artemis/platform/windows.py
@@ -54,6 +54,10 @@ class WindowsPlatformPaths(IPlatformPaths):
             p.mkdir(parents=True, exist_ok=True)
             return p
 
+        legacy_antigravity = self._home / ".gemini" / "antigravity"
+        if legacy_antigravity.exists():
+            return legacy_antigravity
+
         legacy_jetski = self._home / ".gemini" / "jetski"
         if legacy_jetski.exists():
             return legacy_jetski

--- a/mcp_server/notifiers/agentapi.py
+++ b/mcp_server/notifiers/agentapi.py
@@ -53,6 +53,7 @@ class AgentApiNotifier(BaseNotifier):
                 return which_path
 
             candidates = [
+                os.path.expanduser("~/.gemini/antigravity/bin/agentapi"),
                 os.path.expanduser("~/.gemini/jetski/bin/agentapi"),
                 os.path.expanduser("~/.artemis/bin/agentapi"),
                 os.path.expanduser("~/bin/agentapi"),
@@ -81,6 +82,7 @@ class AgentApiNotifier(BaseNotifier):
     def _save_shared_env(self, addr: str, token: str) -> None:
         """Persists recovered environment to shared files for faster subsequent access."""
         shared_candidates = [
+            os.path.expanduser("~/.gemini/antigravity/.antigravity_env"),
             os.path.expanduser("~/.gemini/jetski/.jetski_env"),
             os.path.expanduser("~/.artemis/.artemis_env"),
         ]
@@ -125,6 +127,7 @@ class AgentApiNotifier(BaseNotifier):
         # 2. Shared env files (if not forcing fresh process scan)
         if not force_proc_scan:
             shared_candidates = [
+                os.path.expanduser("~/.gemini/antigravity/.antigravity_env"),
                 os.path.expanduser("~/.gemini/jetski/.jetski_env"),
                 os.path.expanduser("~/.artemis/.artemis_env"),
             ]


### PR DESCRIPTION
### Summary
Resolve modern Antigravity configuration and rules resolution paths across the CLI, Platform Abstraction Layer (PAL), and AgentAPI notifier.

### Motivation & Context
When running `artemis mcp --install antigravity`, rules and configurations were previously targeted to legacy Jetski paths. Modern Antigravity expects rules under `~/.gemini/antigravity/rules/` and config under `~/.gemini/antigravity/mcp_config.json`.

### Changes
- **Rules Installation**: Added `~/.gemini/antigravity/rules/artemis.md` during `artemis mcp --install antigravity` and `artemis mcp --install all`.
- **Config Generation Display**: Corrected Antigravity configuration path label in `artemis mcp --generate-config all` to reference `~/.gemini/antigravity/mcp_config.json`.
- **Platform Abstraction Layer (PAL)**: Updated Windows, Linux, and Darwin platform implementations to check for `~/.gemini/antigravity` before legacy fallbacks.
- **Notifier Candidate Discovery**: Added `~/.gemini/antigravity/bin/agentapi` and `~/.gemini/antigravity/.antigravity_env` discovery to `AgentApiNotifier`.
- **Documentation**: Updated Antigravity path references in both English and Chinese READMEs.
