### PR TITLE
fix(admin_console): handle boolean strings and clear_all parameter in stop endpoint

### DIFF
--- a/apps/admin_console/routers/tasks.py
+++ b/apps/admin_console/routers/tasks.py
@@ -204,22 +204,32 @@ async def list_devices():
     return {"devices": [d.to_dict() for d in devices]}
 
 
+def _parse_bool(val: Any) -> bool:
+    if isinstance(val, bool):
+        return val
+    if isinstance(val, str):
+        return val.strip().lower() in ("true", "1", "yes", "on")
+    return bool(val)
+
+
 @router.post("/api/stop")
 async def stop_task(
     request: Request,
     all: bool = False,
+    clear_all: bool | None = None,
     session_id: str | None = None,
     device_id: str | None = None,
 ):
-    target_all = all
+    target_all = clear_all if clear_all is not None else all
     target_sid = session_id
     target_dev = device_id
 
     try:
         body = await request.json()
         if isinstance(body, dict):
-            if "all" in body:
-                target_all = bool(body["all"]) or target_all
+            raw_all = body.get("clear_all") if "clear_all" in body else body.get("all")
+            if raw_all is not None:
+                target_all = _parse_bool(raw_all)
             if body.get("session_id"):
                 target_sid = str(body["session_id"])
             if body.get("device_id"):

--- a/tests/unit/admin_console/test_stop_task_endpoint.py
+++ b/tests/unit/admin_console/test_stop_task_endpoint.py
@@ -1,0 +1,89 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import MagicMock
+import pytest
+from apps.admin_console.routers import tasks
+
+
+class DummyRequest:
+    def __init__(self, json_data=None):
+        self._json_data = json_data
+
+    async def json(self):
+        if self._json_data is None:
+            raise ValueError("No JSON body")
+        return self._json_data
+
+
+@pytest.mark.parametrize(
+    "body,expected_clear_all",
+    [
+        ({"all": "false"}, False),
+        ({"all": False}, False),
+        ({"all": "0"}, False),
+        ({"clear_all": "false"}, False),
+        ({"clear_all": False}, False),
+        ({"all": "true"}, True),
+        ({"all": True}, True),
+        ({"all": "1"}, True),
+        ({"clear_all": "true"}, True),
+        ({"clear_all": True}, True),
+    ],
+)
+@pytest.mark.asyncio
+async def test_stop_task_boolean_parsing_in_body(monkeypatch, body, expected_clear_all):
+    mock_stop_tasks = MagicMock(return_value=True)
+    monkeypatch.setattr(tasks.task_queue_service, "stop_tasks", mock_stop_tasks)
+
+    req = DummyRequest(json_data=body)
+    resp = await tasks.stop_task(request=req)
+
+    assert resp["status"] == "stopped"
+    mock_stop_tasks.assert_called_once_with(
+        clear_all=expected_clear_all,
+        session_id=None,
+        device_id=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_stop_task_fallback_to_query_params(monkeypatch):
+    mock_stop_tasks = MagicMock(return_value=True)
+    monkeypatch.setattr(tasks.task_queue_service, "stop_tasks", mock_stop_tasks)
+
+    req = DummyRequest(json_data=None)
+    resp = await tasks.stop_task(request=req, all=False, clear_all=None)
+
+    assert resp["status"] == "stopped"
+    mock_stop_tasks.assert_called_once_with(
+        clear_all=False,
+        session_id=None,
+        device_id=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_stop_task_clear_all_query_param_precedence(monkeypatch):
+    mock_stop_tasks = MagicMock(return_value=True)
+    monkeypatch.setattr(tasks.task_queue_service, "stop_tasks", mock_stop_tasks)
+
+    req = DummyRequest(json_data=None)
+    await tasks.stop_task(request=req, all=True, clear_all=False)
+
+    mock_stop_tasks.assert_called_once_with(
+        clear_all=False,
+        session_id=None,
+        device_id=None,
+    )


### PR DESCRIPTION
### Summary of Changes
- Fixes #36: In `apps/admin_console/routers/tasks.py`, passing `"false"` (e.g. from UI requests, query parameters, or stringified JSON) previously evaluated as truthy due to Python's `bool("false") == True`.
- Added a clean `_parse_bool` normalizer that correctly parses truthy and falsy string/boolean representations (`"true"`, `"false"`, `"1"`, `"0"`).
- Extended `stop_task` to support `clear_all` alongside `all` in both query parameters and JSON payloads, matching the underlying `task_queue_service.stop_tasks` interface.
- Removed the `or target_all` short-circuit that prevented an explicit `false` from taking effect.
- Added comprehensive unit tests in `tests/unit/admin_console/test_stop_task_endpoint.py` covering boolean variations, query parameter precedence, and fallback behaviors.

### Verification
- `uv run pytest tests/unit/admin_console/test_stop_task_endpoint.py -v`: 12/12 passed.
- `uv run pytest tests/unit/admin_console/ -v`: 126/126 passed.
- `uv run ruff check apps/admin_console/routers/tasks.py tests/unit/admin_console/test_stop_task_endpoint.py`: All checks passed.
- `uv run ruff format --check`: 0 formatting issues.
- `uv run python scripts/quality_ratchet.py`: Quality ratchet passed.
