### PR TITLE
fix(llm): safely resolve provider and model with enum and fallback support

### DIFF
--- a/artemis/services/llm.py
+++ b/artemis/services/llm.py
@@ -21,6 +21,7 @@ thought stream recording, and role-based dynamic dispatching.
 import asyncio
 from collections.abc import Awaitable, Callable, Coroutine
 from contextvars import ContextVar, Token
+from enum import Enum
 import functools
 import logging
 from pathlib import Path
@@ -1061,8 +1062,8 @@ def _resolve_endpoint(
         val = getattr(obj, attr, None)
         return val if isinstance(val, expected_type) else None
 
-    provider_val = getattr(cfg, "provider", "google")
-    model_val = getattr(cfg, "model", "gemini-2.5-flash")
+    provider_val = _get_val(cfg, "provider", (str, ModelProvider, Enum)) or "google"
+    model_val = _get_val(cfg, "model", (str, Enum)) or "gemini-2.5-flash"
 
     return ModelEndpoint(
         provider=ModelProvider.from_string(provider_val),

--- a/tests/unit/test_llm_gateway.py
+++ b/tests/unit/test_llm_gateway.py
@@ -239,3 +239,37 @@ async def test_mid_stream_failure_records_stream_reset_payload(monkeypatch):
     assert payload["reason"] == "mid_stream_failure"
     assert "stream_exec_id" in payload
     assert "lower API priority" in payload["message"]
+
+
+def test_resolve_endpoint_fallback_and_types():
+    from unittest.mock import MagicMock
+    from artemis.llm.router import ModelProvider
+
+    ctx = MagicMock()
+    # 1. Non-string / mock attributes fall back to defaults
+    mock_agent_cfg = MagicMock()
+    ctx.llm_config.get_agent.return_value = mock_agent_cfg
+
+    ep = llm_service._resolve_endpoint(ctx, "operator")
+    assert ep.provider == ModelProvider.GOOGLE
+    assert ep.model_name == "gemini-2.5-flash"
+
+    # 2. String provider & model
+    str_cfg = MagicMock()
+    str_cfg.provider = "openai"
+    str_cfg.model = "gpt-4o"
+    ctx.llm_config.get_agent.return_value = str_cfg
+
+    ep = llm_service._resolve_endpoint(ctx, "operator")
+    assert ep.provider == ModelProvider.OPENAI
+    assert ep.model_name == "gpt-4o"
+
+    # 3. Enum ModelProvider
+    enum_cfg = MagicMock()
+    enum_cfg.provider = ModelProvider.ANTHROPIC
+    enum_cfg.model = "claude-3-5-sonnet"
+    ctx.llm_config.get_agent.return_value = enum_cfg
+
+    ep = llm_service._resolve_endpoint(ctx, "operator")
+    assert ep.provider == ModelProvider.ANTHROPIC
+    assert ep.model_name == "claude-3-5-sonnet"


### PR DESCRIPTION
### Summary of Changes
- Fixes #33: In `artemis/services/llm.py`, `_resolve_endpoint` extracted `provider_val` and `model_val` using bare `getattr(cfg, "provider", "google")` and `getattr(cfg, "model", "gemini-2.5-flash")`. When `cfg` had mock or non-string attributes (e.g., in unit tests), `getattr` returned the mock attribute instead of falling back to default values, leading to `ValueError: Unknown LLM provider <MagicMock ...>`.
- Updated `_resolve_endpoint` to use `_get_val(cfg, "provider", (str, ModelProvider, Enum)) or "google"` and `_get_val(cfg, "model", (str, Enum)) or "gemini-2.5-flash"`. This cleanly discards invalid/mocked attributes while safely retaining both string names and enum instances (e.g. `ModelProvider.OPENAI`).
- Added unit tests in `tests/unit/test_llm_gateway.py` verifying fallback for mock attributes as well as preservation of string and enum providers.

### Verification
- `uv run pytest tests/unit/test_llm_gateway.py -v`: 10/10 passed.
- `uv run ruff check artemis/services/llm.py tests/unit/test_llm_gateway.py`: All checks passed.
- `uv run ruff format --check artemis/services/llm.py tests/unit/test_llm_gateway.py`: 0 formatting issues.
- `uv run python scripts/quality_ratchet.py`: Quality ratchet passed.
