### PR TITLE
fix(video): fallback to adb screenrecord when scrcpy fails (#9)

### DIFF
--- a/artemis/controllers/unified_controller.py
+++ b/artemis/controllers/unified_controller.py
@@ -33,10 +33,14 @@ from artemis.controllers.types import (
     SwipeStartEndPercentagesRequest,
     TapOutput,
 )
+from artemis.toolchain import find_adb
 from artemis.utils.logger import get_logger
 from artemis.utils.video import (
+    ANDROID_MAX_RECORDING_DURATION_SECONDS,
     ANDROID_RECORDING_SEGMENT_SECONDS,
     DEFAULT_MAX_DURATION_SECONDS,
+    NATIVE_RECORDING_DEVICE_DIR,
+    NATIVE_RECORDING_WATCHDOG_INTERVAL_SECONDS,
     RecordingSession,
     VideoRecordingResult,
     await_scrcpy_first_frame,
@@ -46,6 +50,7 @@ from artemis.utils.video import (
     get_android_display_state,
     get_active_session,
     has_active_session,
+    is_scrcpy_installed,
     normalize_recording_to_mp4,
     remux_recording_to_mp4,
     render_timeline_clip,
@@ -94,6 +99,183 @@ class UnifiedMobileController:
             if process.returncode is None:
                 process.terminate()
                 await asyncio.wait_for(process.wait(), timeout=5.0)
+
+    async def _start_native_recording_segment(
+        self,
+        session: RecordingSession,
+        device_id: str,
+        output_dir: Path,
+    ) -> bool:
+        """Start an adb screenrecord segment as fallback when scrcpy is unavailable."""
+        segment_idx = session.android_segment_index
+        remote_path = f"{NATIVE_RECORDING_DEVICE_DIR}/rec_{segment_idx:03d}.mp4"
+
+        adb_bin = find_adb()
+        try:
+            mkdir_proc = await asyncio.create_subprocess_exec(
+                adb_bin,
+                "-s",
+                device_id,
+                "shell",
+                "mkdir",
+                "-p",
+                NATIVE_RECORDING_DEVICE_DIR,
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+            if hasattr(mkdir_proc, "wait"):
+                wait_val = mkdir_proc.wait()
+                if asyncio.iscoroutine(wait_val):
+                    await wait_val
+
+            command = [
+                adb_bin,
+                "-s",
+                device_id,
+                "shell",
+                "screenrecord",
+                "--time-limit",
+                str(ANDROID_MAX_RECORDING_DURATION_SECONDS),
+                remote_path,
+            ]
+            process = await self._spawn_scrcpy(command)
+
+            await asyncio.sleep(0.5)
+            if process.returncode is not None:
+                stderr = await process.stderr.read() if process.stderr else b""
+                logger.error(
+                    f"Native screenrecord failed on {device_id}: {stderr.decode(errors='replace')}"
+                )
+                return False
+
+            session.process = process
+            session.native_device_segments.append(remote_path)
+            session.android_segment_started_at = time.time()
+            local_path = output_dir / (
+                "recording.mp4" if segment_idx == 0 else f"recording_{segment_idx:03d}.mp4"
+            )
+            session.local_video_path = local_path
+            logger.info(
+                f"Native screenrecord segment {segment_idx} started on {device_id} -> {remote_path}"
+            )
+            return True
+        except (OSError, subprocess.SubprocessError, TimeoutError) as exc:
+            logger.error(f"Error starting native recording on {device_id}: {exc}")
+            return False
+
+    async def _pull_native_segment(
+        self,
+        device_id: str,
+        remote_path: str,
+        local_path: Path,
+    ) -> bool:
+        """Pull a completed native recording segment from device and remove remote file."""
+        adb_bin = find_adb()
+        try:
+            pull_proc = await asyncio.create_subprocess_exec(
+                adb_bin,
+                "-s",
+                device_id,
+                "pull",
+                remote_path,
+                str(local_path),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            if hasattr(pull_proc, "wait"):
+                wait_val = pull_proc.wait()
+                if asyncio.iscoroutine(wait_val):
+                    await asyncio.wait_for(wait_val, timeout=30.0)
+            if (
+                pull_proc.returncode != 0
+                or not local_path.exists()
+                or local_path.stat().st_size == 0
+            ):
+                logger.warning(f"Failed to pull native segment: {remote_path}")
+                return False
+
+            rm_proc = await asyncio.create_subprocess_exec(
+                adb_bin,
+                "-s",
+                device_id,
+                "shell",
+                "rm",
+                "-f",
+                remote_path,
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+            if hasattr(rm_proc, "wait"):
+                rm_val = rm_proc.wait()
+                if asyncio.iscoroutine(rm_val):
+                    await rm_val
+            return True
+        except (OSError, subprocess.SubprocessError, TimeoutError) as exc:
+            logger.warning(f"Error pulling native segment {remote_path}: {exc}")
+            return False
+
+    async def _native_recording_watchdog(self, device_id: str) -> None:
+        """Roll native screenrecord segments at the 180s boundary."""
+        try:
+            while True:
+                await asyncio.sleep(NATIVE_RECORDING_WATCHDOG_INTERVAL_SECONDS)
+                session = get_active_session(device_id)
+                if not session or not session.is_active or not session.process:
+                    return
+
+                if session.process.returncode is None:
+                    continue
+
+                if not session.native_device_segments:
+                    return
+
+                segment_idx = session.android_segment_index
+                remote_path = session.native_device_segments[-1]
+                if not session.local_video_path:
+                    return
+                output_dir = session.local_video_path.parent
+                local_path = output_dir / (
+                    "recording.mp4" if segment_idx == 0 else f"recording_{segment_idx:03d}.mp4"
+                )
+
+                end_time = time.time()
+                pulled = await self._pull_native_segment(device_id, remote_path, local_path)
+                if pulled:
+                    start_offset = (
+                        session.android_segment_started_at or session.start_time
+                    ) - session.start_time
+                    session.android_segment_records.append(
+                        {
+                            "path": local_path,
+                            "output_path": local_path,
+                            "start": max(0.0, start_offset),
+                            "end": max(0.0, end_time - session.start_time),
+                            "rotation": session.android_rotation,
+                            "generation": session.generation,
+                            "conversion_scheduled": True,
+                        }
+                    )
+                    session.android_video_segments.append(local_path)
+                    session.sealed_until = max(
+                        session.sealed_until,
+                        max(0.0, end_time - session.start_time),
+                    )
+
+                if not session.is_active:
+                    return
+
+                session.android_segment_index += 1
+                session.generation = session.android_segment_index
+                logger.info(
+                    f"Rolling native recording segment after time limit (next index: {session.android_segment_index})"
+                )
+                if not await self._start_native_recording_segment(session, device_id, output_dir):
+                    logger.error("Failed to start next native recording segment")
+                    return
+        except asyncio.CancelledError:
+            return
+        except (OSError, subprocess.SubprocessError, TimeoutError, RuntimeError) as e:
+            logger.error(f"Error in native recording watchdog for {device_id}: {e}")
 
     async def tap_at(
         self,
@@ -653,25 +835,64 @@ class UnifiedMobileController:
             if display_state:
                 session.capture_width, session.capture_height = display_state[1:]
 
-            # Start scrcpy in background
+            # Try starting scrcpy in background, falling back to native screenrecord
+            process: asyncio.subprocess.Process | None = None
+            scrcpy_error_msg: str | None = None
+            spawned_at: float = start_time
+            first_frame_at: float = start_time
+
             cmd = build_scrcpy_record_command("scrcpy", device_id, local_video_path)
+            try:
+                process = await self._spawn_scrcpy(cmd)
+                spawned_at = time.time()
+                session.process = process
+                set_active_session(device_id, session)
+                logger.info(
+                    f"Started scrcpy recording on {device_id}, saving to {local_video_path}"
+                )
+                first_frame_at = await await_scrcpy_first_frame(process, spawned_at)
+                if process.returncode is not None:
+                    stderr = await process.stderr.read() if process.stderr else b""
+                    scrcpy_error_msg = stderr.decode(errors="replace")
+            except (FileNotFoundError, OSError) as e:
+                scrcpy_error_msg = str(e)
+                set_active_session(device_id, session)
 
-            process = await self._spawn_scrcpy(cmd)
-            spawned_at = time.time()
+            if process is None or process.returncode is not None:
+                err_msg = scrcpy_error_msg or "unknown error"
+                logger.warning(
+                    f"scrcpy unavailable on {device_id}: {err_msg}; "
+                    "attempting native screenrecord fallback"
+                )
 
-            session.process = process
-            set_active_session(device_id, session)
+                session.recording_backend = "native"
+                session.local_video_path = output_dir / "recording.mp4"
+                if await self._start_native_recording_segment(session, device_id, output_dir):
+                    session.start_time = time.time()
+                    session.android_segment_started_at = session.start_time
 
-            logger.info(f"Started scrcpy recording on {device_id}, saving to {local_video_path}")
+                    if self.ctx and self.ctx.data_engine:
+                        self.ctx.data_engine.record_video_start(
+                            video_id=video_id,
+                            device_id=device_id,
+                            local_video_path=session.local_video_path,
+                            start_time=session.start_time,
+                        )
 
-            # The file's t=0 is the first captured frame, about a second after
-            # spawn. Anchor the recording timeline there: segment offsets and
-            # analyzer clip trimming all treat session.start_time as that t=0.
-            first_frame_at = await await_scrcpy_first_frame(process, spawned_at)
-            if process.returncode is not None:
-                stderr = await process.stderr.read()
-                err_msg = stderr.decode()
-                logger.error(f"scrcpy failed to start on {device_id}: {err_msg}")
+                    session.watchdog_task = asyncio.create_task(
+                        self._native_recording_watchdog(device_id)
+                    )
+                    logger.info(f"Native screenrecord fallback active on {device_id}")
+                    return VideoRecordingResult(
+                        success=True,
+                        message=f"Recording started on {device_id} (native fallback)",
+                        video_id=session.video_id,
+                        generation=session.generation,
+                        sealed_until=session.sealed_until,
+                        source_revision=f"{session.video_id}:{session.generation}:active",
+                    )
+
+                logger.error(f"Both scrcpy and native screenrecord failed on {device_id}")
                 if self.ctx and self.ctx.data_engine:
                     self.ctx.data_engine.record_video_start(
                         video_id=video_id,
@@ -679,11 +900,13 @@ class UnifiedMobileController:
                         local_video_path=local_video_path,
                         start_time=session.start_time,
                     )
-                self._record_recording_failure(session, f"scrcpy failed to start: {err_msg}")
+                self._record_recording_failure(
+                    session, f"scrcpy failed ({err_msg}); native fallback also failed"
+                )
                 remove_active_session(device_id)
                 return VideoRecordingResult(
                     success=False,
-                    message=f"scrcpy failed to start: {err_msg}",
+                    message="Both scrcpy and native screenrecord failed to start",
                 )
 
             session.start_time = first_frame_at
@@ -769,8 +992,67 @@ class UnifiedMobileController:
             if process is not None:
                 try:
                     await self._stop_scrcpy(process)
-                except Exception as proc_e:
-                    logger.warning(f"Error terminating scrcpy process: {proc_e}")
+                except (
+                    OSError,
+                    subprocess.SubprocessError,
+                    TimeoutError,
+                    ProcessLookupError,
+                ) as proc_e:
+                    logger.warning(f"Error terminating recording process: {proc_e}")
+
+            if session.recording_backend == "native" and session.native_device_segments:
+                final_remote = session.native_device_segments[-1]
+                segment_idx = session.android_segment_index
+                if session.local_video_path:
+                    local_path = session.local_video_path.parent / (
+                        "recording.mp4" if segment_idx == 0 else f"recording_{segment_idx:03d}.mp4"
+                    )
+                    end_time = time.time()
+                    pulled = await self._pull_native_segment(device_id, final_remote, local_path)
+                    if pulled and local_path.exists() and local_path.stat().st_size > 0:
+                        if not any(
+                            Path(r.get("path", "")) == local_path
+                            for r in session.android_segment_records
+                        ):
+                            start_offset = (
+                                session.android_segment_started_at or session.start_time
+                            ) - session.start_time
+                            session.android_segment_records.append(
+                                {
+                                    "path": local_path,
+                                    "output_path": local_path,
+                                    "start": max(0.0, start_offset),
+                                    "end": max(0.0, end_time - session.start_time),
+                                    "rotation": session.android_rotation,
+                                    "generation": session.generation,
+                                    "conversion_scheduled": True,
+                                }
+                            )
+                            session.android_video_segments.append(local_path)
+                            session.sealed_until = max(
+                                session.sealed_until,
+                                max(0.0, end_time - session.start_time),
+                            )
+
+                try:
+                    adb_bin = find_adb()
+                    rm_proc = await asyncio.create_subprocess_exec(
+                        adb_bin,
+                        "-s",
+                        device_id,
+                        "shell",
+                        "rm",
+                        "-rf",
+                        NATIVE_RECORDING_DEVICE_DIR,
+                        stdout=asyncio.subprocess.DEVNULL,
+                        stderr=asyncio.subprocess.DEVNULL,
+                    )
+                    if hasattr(rm_proc, "wait"):
+                        rm_val = rm_proc.wait()
+                        if asyncio.iscoroutine(rm_val):
+                            await rm_val
+                except (OSError, subprocess.SubprocessError, TimeoutError) as e:
+                    logger.debug(f"Device recording cleanup failed: {e}")
 
             output_path = session.local_video_path
             has_existing_recording = (output_path and output_path.exists()) or any(

--- a/artemis/utils/video.py
+++ b/artemis/utils/video.py
@@ -46,6 +46,8 @@ SCRCPY_STARTUP_TIMEOUT_SECONDS = 6.0
 VIDEO_READY_DELAY_SECONDS = 1
 ANDROID_DEVICE_VIDEO_PATH = "/sdcard/screen_recording.mp4"
 ANDROID_MAX_RECORDING_DURATION_SECONDS = 180  # Android screenrecord limit
+NATIVE_RECORDING_DEVICE_DIR = "/data/local/tmp/artemis"
+NATIVE_RECORDING_WATCHDOG_INTERVAL_SECONDS = 1.0
 # Ignore small timing differences at segment boundaries.
 TIMELINE_GAP_EPSILON_SECONDS = 0.05
 
@@ -167,6 +169,8 @@ class RecordingSession(BaseModel):
     sealed_until: float = 0.0
     is_active: bool = True
     errors: list[str] = []
+    recording_backend: str = "scrcpy"
+    native_device_segments: list[str] = []
 
 
 class VideoRecordingResult(BaseModel):
@@ -389,41 +393,62 @@ async def remux_recording_to_mp4(source_path: Path, output_path: Path) -> bool:
 
 async def probe_video_segment(video_path: Path) -> dict[str, float | int]:
     """Read duration and coded dimensions for a finalized segment."""
-    process = await asyncio.create_subprocess_exec(
-        get_ffprobe_path(),
-        "-v",
-        "error",
-        "-show_entries",
-        "stream=width,height,duration,codec_type:format=duration",
-        "-of",
-        "json",
-        str(video_path),
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-    )
-    stdout, _stderr = await process.communicate()
-    if process.returncode != 0:
-        return {}
     try:
-        payload = json.loads(stdout)
-        streams = payload.get("streams") or []
-        video_stream = next(
-            (s for s in streams if s.get("width") and s.get("height")),
-            next(
-                (s for s in streams if s.get("codec_type") == "video"),
-                streams[0] if streams else {},
-            ),
+        process = await asyncio.create_subprocess_exec(
+            get_ffprobe_path(),
+            "-v",
+            "error",
+            "-show_entries",
+            "stream=width,height,duration,codec_type:format=duration",
+            "-of",
+            "json",
+            str(video_path),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
         )
-        duration = float(
-            (payload.get("format") or {}).get("duration") or video_stream.get("duration") or 0
-        )
-        return {
-            "duration": duration,
-            "width": int(video_stream.get("width") or 0),
-            "height": int(video_stream.get("height") or 0),
-        }
-    except (TypeError, ValueError, json.JSONDecodeError):
-        return {}
+        stdout, _stderr = await process.communicate()
+        if process.returncode == 0:
+            payload = json.loads(stdout)
+            streams = payload.get("streams") or []
+            video_stream = next(
+                (s for s in streams if s.get("width") and s.get("height")),
+                next(
+                    (s for s in streams if s.get("codec_type") == "video"),
+                    streams[0] if streams else {},
+                ),
+            )
+            duration = float(
+                (payload.get("format") or {}).get("duration") or video_stream.get("duration") or 0
+            )
+            if duration > 0:
+                return {
+                    "duration": duration,
+                    "width": int(video_stream.get("width") or 0),
+                    "height": int(video_stream.get("height") or 0),
+                }
+    except (TypeError, ValueError, json.JSONDecodeError, OSError, subprocess.SubprocessError):
+        pass
+
+    # OpenCV fallback for environments where ffprobe is not installed
+    try:
+        cap = cv2.VideoCapture(str(video_path))
+        if cap.isOpened():
+            fps = float(cap.get(cv2.CAP_PROP_FPS) or 30.0)
+            frame_count = float(cap.get(cv2.CAP_PROP_FRAME_COUNT) or 0.0)
+            width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH) or 0)
+            height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT) or 0)
+            duration = (frame_count / fps) if fps > 0 else 0.0
+            cap.release()
+            if duration > 0 and width > 0 and height > 0:
+                return {
+                    "duration": round(duration, 3),
+                    "width": width,
+                    "height": height,
+                }
+    except (cv2.error, OSError, ValueError):
+        pass
+
+    return {}
 
 
 async def get_android_display_state(device_id: str) -> tuple[int, int, int] | None:
@@ -659,9 +684,24 @@ def is_scrcpy_installed() -> bool:
     return shutil.which("scrcpy") is not None
 
 
+def is_adb_installed() -> bool:
+    """Check if adb is available in the system PATH."""
+    return shutil.which("adb") is not None
+
+
+is_adb_available = is_adb_installed
+
+
 def detect_video_tools_enabled() -> bool:
-    """Check if both scrcpy and ffmpeg are available to enable automated video features."""
-    return is_ffmpeg_installed() and is_scrcpy_installed()
+    """Check if video recording tools are available.
+
+    Recording is enabled when either the scrcpy+ffmpeg stack is present
+    (for high-quality MKV capture with remuxing) or when adb alone is
+    available (for native screenrecord fallback producing MP4 directly).
+    """
+    if is_ffmpeg_installed() and is_scrcpy_installed():
+        return True
+    return is_adb_installed()
 
 
 class FFmpegNotInstalledError(Exception):

--- a/tests/unit/test_native_screenrecord_fallback.py
+++ b/tests/unit/test_native_screenrecord_fallback.py
@@ -1,0 +1,402 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for native screenrecord fallback when scrcpy is unavailable."""
+
+import asyncio
+from pathlib import Path
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from artemis.context import ArtemisContext
+from artemis.controllers.unified_controller import UnifiedMobileController
+from artemis.drivers.mock.mock_driver import MockDeviceDriver
+from artemis.utils.video import (
+    NATIVE_RECORDING_DEVICE_DIR,
+    RecordingSession,
+    detect_video_tools_enabled,
+    get_active_session,
+    is_adb_available,
+    is_adb_installed,
+    is_scrcpy_installed,
+    probe_video_segment,
+    remove_active_session,
+    set_active_session,
+)
+
+
+@pytest.fixture
+def mock_ctx():
+    ctx = MagicMock(spec=ArtemisContext)
+    ctx.device = MagicMock()
+    ctx.device.device_id = "real-device-1234"
+    ctx.device.mobile_platform = "android"
+    ctx.device.device_width = 1080
+    ctx.device.device_height = 2400
+
+    # DataEngine mock
+    ctx.data_engine = MagicMock()
+    ctx.data_engine.current_session_id = uuid4()
+    ctx.data_engine.session_start_time = time.time()
+    ctx.data_engine.storage = MagicMock()
+
+    mock_driver = MockDeviceDriver(device_id="real-device-1234")
+    ctx._active_driver = mock_driver
+    return ctx
+
+
+class _FakeProcess:
+    """Mock process mimicking asyncio.subprocess.Process."""
+
+    def __init__(self, returncode: int | None = None, stderr: bytes = b""):
+        self.returncode = returncode
+        self._stderr = stderr
+        self.stderr = AsyncMock()
+        self.stderr.read = AsyncMock(return_value=self._stderr)
+        self.stdout = AsyncMock()
+        self.stdout.read = AsyncMock(return_value=b"")
+
+    async def wait(self) -> int:
+        return self.returncode if self.returncode is not None else 0
+
+    def send_signal(self, sig: int) -> None:
+        self.returncode = 0
+
+    def terminate(self) -> None:
+        self.returncode = -15
+
+
+# --- Detection Tests ---
+
+
+def test_detect_video_tools_scrcpy_and_ffmpeg():
+    with (
+        patch("artemis.utils.video.is_ffmpeg_installed", return_value=True),
+        patch("artemis.utils.video.is_scrcpy_installed", return_value=True),
+        patch("artemis.utils.video.is_adb_installed", return_value=False),
+    ):
+        assert detect_video_tools_enabled() is True
+
+
+def test_detect_video_tools_adb_only():
+    with (
+        patch("artemis.utils.video.is_ffmpeg_installed", return_value=False),
+        patch("artemis.utils.video.is_scrcpy_installed", return_value=False),
+        patch("artemis.utils.video.is_adb_installed", return_value=True),
+    ):
+        assert detect_video_tools_enabled() is True
+        assert is_adb_available() is True
+
+
+def test_detect_video_tools_nothing():
+    with (
+        patch("artemis.utils.video.is_ffmpeg_installed", return_value=False),
+        patch("artemis.utils.video.is_scrcpy_installed", return_value=False),
+        patch("artemis.utils.video.is_adb_installed", return_value=False),
+    ):
+        assert detect_video_tools_enabled() is False
+
+
+# --- RecordingSession Model Tests ---
+
+
+def test_recording_session_defaults_and_backend():
+    session = RecordingSession(
+        video_id=uuid4(),
+        device_id="dev-1",
+        start_time=100.0,
+    )
+    assert session.recording_backend == "scrcpy"
+    assert session.native_device_segments == []
+
+    native_session = RecordingSession(
+        video_id=uuid4(),
+        device_id="dev-2",
+        start_time=100.0,
+        recording_backend="native",
+        native_device_segments=["/data/local/tmp/artemis/rec_000.mp4"],
+    )
+    assert native_session.recording_backend == "native"
+    assert len(native_session.native_device_segments) == 1
+
+
+# --- Controller Fallback Tests ---
+
+
+@pytest.mark.asyncio
+async def test_start_native_fallback_on_scrcpy_failure(mock_ctx, tmp_path):
+    device_id = "real-device-1234"
+    remove_active_session(device_id)
+    controller = UnifiedMobileController(mock_ctx)
+
+    # Scrcpy process exits immediately with error
+    scrcpy_proc = _FakeProcess(returncode=1, stderr=b"ERROR: Encoder rejected format")
+    # Native process runs successfully
+    native_proc = _FakeProcess(returncode=None)
+
+    async def fake_spawn(command):
+        if "scrcpy" in command[0]:
+            return scrcpy_proc
+        return native_proc
+
+    with (
+        patch("artemis.controllers.unified_controller.is_scrcpy_installed", return_value=True),
+        patch.object(controller, "_spawn_scrcpy", side_effect=fake_spawn),
+        patch(
+            "artemis.controllers.unified_controller.get_android_display_state",
+            AsyncMock(return_value=(0, 1080, 2400)),
+        ),
+        patch("asyncio.create_subprocess_exec", AsyncMock(return_value=_FakeProcess(returncode=0))),
+        patch("asyncio.sleep", AsyncMock()),
+    ):
+        res = await controller.start_video_recording(output_dir=tmp_path)
+
+        assert res.success is True
+        assert "native fallback" in res.message
+        session = get_active_session(device_id)
+        assert session is not None
+        assert session.recording_backend == "native"
+        assert len(session.native_device_segments) == 1
+        assert session.native_device_segments[0].endswith("rec_000.mp4")
+        assert session.watchdog_task is not None
+
+        # Clean up
+        if session.watchdog_task and not session.watchdog_task.done():
+            session.watchdog_task.cancel()
+    remove_active_session(device_id)
+
+
+@pytest.mark.asyncio
+async def test_start_native_fallback_when_scrcpy_not_installed(mock_ctx, tmp_path):
+    device_id = "real-device-1234"
+    remove_active_session(device_id)
+    controller = UnifiedMobileController(mock_ctx)
+
+    native_proc = _FakeProcess(returncode=None)
+
+    async def fake_spawn(command):
+        if "scrcpy" in command[0]:
+            raise FileNotFoundError("scrcpy not found")
+        return native_proc
+
+    with (
+        patch("artemis.controllers.unified_controller.is_scrcpy_installed", return_value=False),
+        patch.object(controller, "_spawn_scrcpy", side_effect=fake_spawn),
+        patch(
+            "artemis.controllers.unified_controller.get_android_display_state",
+            AsyncMock(return_value=None),
+        ),
+        patch("asyncio.create_subprocess_exec", AsyncMock(return_value=_FakeProcess(returncode=0))),
+        patch("asyncio.sleep", AsyncMock()),
+    ):
+        res = await controller.start_video_recording(output_dir=tmp_path)
+
+        assert res.success is True
+        assert "native fallback" in res.message
+        session = get_active_session(device_id)
+        assert session is not None
+        assert session.recording_backend == "native"
+
+        # Clean up
+        if session.watchdog_task and not session.watchdog_task.done():
+            session.watchdog_task.cancel()
+    remove_active_session(device_id)
+
+
+@pytest.mark.asyncio
+async def test_start_native_fallback_both_fail(mock_ctx, tmp_path):
+    device_id = "real-device-1234"
+    remove_active_session(device_id)
+    controller = UnifiedMobileController(mock_ctx)
+
+    scrcpy_proc = _FakeProcess(returncode=1, stderr=b"scrcpy error")
+    native_proc = _FakeProcess(returncode=2, stderr=b"screenrecord: failed to create encoder")
+
+    async def fake_spawn(command):
+        if "scrcpy" in command[0]:
+            return scrcpy_proc
+        return native_proc
+
+    with (
+        patch("artemis.controllers.unified_controller.is_scrcpy_installed", return_value=True),
+        patch.object(controller, "_spawn_scrcpy", side_effect=fake_spawn),
+        patch(
+            "artemis.controllers.unified_controller.get_android_display_state",
+            AsyncMock(return_value=None),
+        ),
+        patch("asyncio.create_subprocess_exec", AsyncMock(return_value=_FakeProcess(returncode=0))),
+        patch("asyncio.sleep", AsyncMock()),
+    ):
+        res = await controller.start_video_recording(output_dir=tmp_path)
+
+        assert res.success is False
+        assert "Both scrcpy and native screenrecord failed" in res.message
+        assert get_active_session(device_id) is None
+    remove_active_session(device_id)
+
+
+@pytest.mark.asyncio
+async def test_stop_native_recording_pulls_segment_and_writes_manifest(mock_ctx, tmp_path):
+    device_id = "real-device-1234"
+    remove_active_session(device_id)
+    controller = UnifiedMobileController(mock_ctx)
+
+    mock_proc = _FakeProcess(returncode=None)
+    local_mp4 = tmp_path / "recording.mp4"
+    remote_path = f"{NATIVE_RECORDING_DEVICE_DIR}/rec_000.mp4"
+
+    session = RecordingSession(
+        video_id=uuid4(),
+        device_id=device_id,
+        start_time=time.time() - 10.0,
+        data_engine_start_time=time.time() - 10.0,
+        local_video_path=local_mp4,
+        process=mock_proc,
+        recording_backend="native",
+        native_device_segments=[remote_path],
+    )
+    set_active_session(device_id, session)
+
+    async def fake_pull(dev_id, remote, local):
+        local.write_bytes(b"native mp4 content")
+        return True
+
+    with (
+        patch.object(controller, "_pull_native_segment", side_effect=fake_pull),
+        patch(
+            "artemis.controllers.unified_controller.write_recording_manifest",
+            AsyncMock(return_value=tmp_path / "recording.json"),
+        ),
+        patch("asyncio.create_subprocess_exec", AsyncMock(return_value=_FakeProcess(returncode=0))),
+    ):
+        res = await controller.stop_video_recording()
+
+        assert res.success is True
+        assert res.video_path == local_mp4
+        assert local_mp4.exists()
+        assert get_active_session(device_id) is None
+        assert mock_ctx.data_engine.record_video_stop.called
+    remove_active_session(device_id)
+
+
+@pytest.mark.asyncio
+async def test_pull_native_segment_success(mock_ctx, tmp_path):
+    controller = UnifiedMobileController(mock_ctx)
+    local_path = tmp_path / "recording.mp4"
+    remote_path = f"{NATIVE_RECORDING_DEVICE_DIR}/rec_000.mp4"
+
+    async def fake_subproc(*args, **kwargs):
+        if "pull" in args:
+            local_path.write_bytes(b"video bytes")
+            return _FakeProcess(returncode=0)
+        return _FakeProcess(returncode=0)
+
+    with patch("asyncio.create_subprocess_exec", side_effect=fake_subproc):
+        result = await controller._pull_native_segment("device-1", remote_path, local_path)
+        assert result is True
+        assert local_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_pull_native_segment_failure_on_nonzero_exit(mock_ctx, tmp_path):
+    controller = UnifiedMobileController(mock_ctx)
+    local_path = tmp_path / "recording.mp4"
+    remote_path = f"{NATIVE_RECORDING_DEVICE_DIR}/rec_000.mp4"
+
+    with patch(
+        "asyncio.create_subprocess_exec",
+        AsyncMock(return_value=_FakeProcess(returncode=1)),
+    ):
+        result = await controller._pull_native_segment("device-1", remote_path, local_path)
+        assert result is False
+
+
+@pytest.mark.asyncio
+async def test_native_recording_watchdog_rolls_segment(mock_ctx, tmp_path):
+    device_id = "real-device-1234"
+    remove_active_session(device_id)
+    controller = UnifiedMobileController(mock_ctx)
+
+    local_mp4 = tmp_path / "recording.mp4"
+    proc_segment_0 = _FakeProcess(returncode=0)  # Exited at 180s limit
+    proc_segment_1 = _FakeProcess(returncode=None)  # New active segment
+
+    session = RecordingSession(
+        video_id=uuid4(),
+        device_id=device_id,
+        start_time=time.time() - 180.0,
+        local_video_path=local_mp4,
+        process=proc_segment_0,
+        recording_backend="native",
+        native_device_segments=[f"{NATIVE_RECORDING_DEVICE_DIR}/rec_000.mp4"],
+    )
+    set_active_session(device_id, session)
+
+    async def fake_pull(dev_id, remote, local):
+        local.write_bytes(b"segment 0 content")
+        return True
+
+    async def fake_start_next(sess, dev_id, out_dir):
+        sess.process = proc_segment_1
+        sess.native_device_segments.append(f"{NATIVE_RECORDING_DEVICE_DIR}/rec_001.mp4")
+        sess.is_active = False  # Stop watchdog after one roll
+        return True
+
+    with (
+        patch.object(controller, "_pull_native_segment", side_effect=fake_pull),
+        patch.object(controller, "_start_native_recording_segment", side_effect=fake_start_next),
+        patch("asyncio.sleep", AsyncMock()),
+    ):
+        await controller._native_recording_watchdog(device_id)
+
+        assert session.android_segment_index == 1
+        assert len(session.android_segment_records) == 1
+        assert session.android_segment_records[0]["path"] == local_mp4
+
+    remove_active_session(device_id)
+
+
+@pytest.mark.asyncio
+async def test_probe_video_segment_fallback_to_cv2(tmp_path):
+    import cv2
+    import numpy as np
+
+    video_path = tmp_path / "probe_test.mp4"
+    fourcc = cv2.VideoWriter_fourcc(*"mp4v")
+    out = cv2.VideoWriter(str(video_path), fourcc, 30.0, (640, 480))
+    for _ in range(30):
+        out.write(np.zeros((480, 640, 3), dtype=np.uint8))
+    out.release()
+
+    with patch(
+        "asyncio.create_subprocess_exec", side_effect=FileNotFoundError("ffprobe not found")
+    ):
+        metadata = await probe_video_segment(video_path)
+
+        assert metadata["width"] == 640
+        assert metadata["height"] == 480
+        assert 0.9 <= metadata["duration"] <= 1.1
+
+
+@pytest.mark.asyncio
+async def test_probe_video_segment_nonexistent_file(tmp_path):
+    video_path = tmp_path / "nonexistent.mp4"
+    with patch(
+        "asyncio.create_subprocess_exec", side_effect=FileNotFoundError("ffprobe not found")
+    ):
+        metadata = await probe_video_segment(video_path)
+        assert metadata == {}


### PR DESCRIPTION
Fixes #9.

### Problem
On real Android devices, screen recordings often fail to appear in the traces directory (showing "No Video Recording Available" in the console). This usually happens when `scrcpy` isn't installed on the machine, or when scrcpy fails at runtime due to device-specific issues like rejected H.264 encoders or secure display flags.

### Solution
- Fall back to native `adb shell screenrecord` when `scrcpy` fails to launch or exits immediately.
- Enable video recording features if `adb` is available (`detect_video_tools_enabled`), so scrcpy is no longer a hard prerequisite.
- Handle Android's built-in 180-second `screenrecord` limit via a background watchdog that rolls and pulls segments as they finish.
- On recording stop, flush the recording with SIGINT, pull the MP4 to the traces directory, register it in the playlist manifest and DataEngine, and clean up temporary files from `/data/local/tmp/artemis`.
- Added OpenCV fallback to `probe_video_segment` so missing `ffprobe` binaries don't crash manifest generation.
- Added comprehensive unit tests in `tests/unit/test_native_screenrecord_fallback.py`.

### Testing
- `uv run pytest tests/unit/test_native_screenrecord_fallback.py` (13 passed)
- `uv run ruff check` & `uv run ruff format --check` (clean)
- `uv run pyright --project pyright-core.json` (0 errors)
- `uv run python scripts/quality_ratchet.py` (passed)
- `python3 scripts/check_dependency_sources.py` (passed)