### PR TITLE
fix(mcp): isolate notifier subprocess stdin and sanitize desktop notification strings

### DIFF
--- a/mcp_server/notifiers/agentapi.py
+++ b/mcp_server/notifiers/agentapi.py
@@ -242,6 +242,7 @@ class AgentApiNotifier(BaseNotifier):
                 try:
                     subprocess.run(
                         cmd,
+                        stdin=subprocess.DEVNULL,
                         capture_output=True,
                         text=True,
                         check=True,
@@ -267,6 +268,7 @@ class AgentApiNotifier(BaseNotifier):
                 try:
                     subprocess.run(
                         cmd,
+                        stdin=subprocess.DEVNULL,
                         capture_output=True,
                         text=True,
                         check=True,

--- a/mcp_server/notifiers/desktop.py
+++ b/mcp_server/notifiers/desktop.py
@@ -26,6 +26,30 @@ from mcp_server.notifiers.base import BaseNotifier
 logger = logging.getLogger("mcp_server.notifiers.desktop")
 
 
+def escape_applescript_string(text: str) -> str:
+    """Escapes a string for safe inclusion in an AppleScript double-quoted literal.
+
+    - Escapes backslashes (\\ -> \\\\)
+    - Escapes double quotes (" -> \\")
+    - Replaces newlines and carriage returns with spaces
+    - Preserves single quotes/apostrophes, Unicode, and punctuation safely
+    """
+    escaped = text.replace("\\", "\\\\").replace('"', '\\"')
+    return escaped.replace("\r\n", " ").replace("\n", " ").replace("\r", " ")
+
+
+def escape_powershell_string(text: str) -> str:
+    """Escapes a string for safe inclusion in a PowerShell double-quoted string.
+
+    - Escapes backticks (` -> ``)
+    - Escapes double quotes (" -> `")
+    - Escapes dollar signs ($ -> `$)
+    - Replaces newlines and carriage returns with spaces
+    """
+    escaped = text.replace("`", "``").replace('"', '`"').replace("$", "`$")
+    return escaped.replace("\r\n", " ").replace("\n", " ").replace("\r", " ")
+
+
 class DesktopNotifier(BaseNotifier):
     """Notifier that displays native desktop notifications across macOS, Linux, and Windows."""
 
@@ -71,6 +95,7 @@ class DesktopNotifier(BaseNotifier):
                 if shutil.which("notify-send"):
                     subprocess.run(
                         ["notify-send", header, clean_body],
+                        stdin=subprocess.DEVNULL,
                         stdout=subprocess.DEVNULL,
                         stderr=subprocess.DEVNULL,
                         timeout=3,
@@ -78,26 +103,32 @@ class DesktopNotifier(BaseNotifier):
                     return True
             elif sys.platform == "darwin":
                 if shutil.which("osascript"):
-                    script = f'display notification "{clean_body}" with title "{header}"'
+                    esc_body = escape_applescript_string(clean_body)
+                    esc_header = escape_applescript_string(header)
+                    script = f'display notification "{esc_body}" with title "{esc_header}"'
                     subprocess.run(
                         ["osascript", "-e", script],
+                        stdin=subprocess.DEVNULL,
                         stdout=subprocess.DEVNULL,
                         stderr=subprocess.DEVNULL,
                         timeout=3,
                     )
                     return True
             elif sys.platform == "win32":
+                esc_header = escape_powershell_string(header)
+                esc_body = escape_powershell_string(clean_body)
                 ps_cmd = (
                     f"[Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime] > $null; "
                     f"$template = [Windows.UI.Notifications.ToastNotificationManager]::GetTemplateContent([Windows.UI.Notifications.ToastTemplateType]::ToastText02); "
                     f'$textNodes = $template.GetElementsByTagName("text"); '
-                    f'$textNodes.Item(0).AppendChild($template.CreateTextNode("{header}")) > $null; '
-                    f'$textNodes.Item(1).AppendChild($template.CreateTextNode("{clean_body}")) > $null; '
+                    f'$textNodes.Item(0).AppendChild($template.CreateTextNode("{esc_header}")) > $null; '
+                    f'$textNodes.Item(1).AppendChild($template.CreateTextNode("{esc_body}")) > $null; '
                     f"$toast = [Windows.UI.Notifications.ToastNotification]::new($template); "
                     f'[Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier("Artemis").Show($toast);'
                 )
                 subprocess.run(
                     ["powershell", "-NoProfile", "-Command", ps_cmd],
+                    stdin=subprocess.DEVNULL,
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.DEVNULL,
                     timeout=5,

--- a/mcp_server/notifiers/script.py
+++ b/mcp_server/notifiers/script.py
@@ -78,6 +78,7 @@ class ScriptNotifier(BaseNotifier):
             )
             subprocess.run(
                 cmd,
+                stdin=subprocess.DEVNULL,
                 shell=True,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,

--- a/tests/unit/mcp/test_mcp_stdio_lifecycle.py
+++ b/tests/unit/mcp/test_mcp_stdio_lifecycle.py
@@ -30,6 +30,13 @@ from artemis.clients import ui_automator_client
 from artemis.runtime.awake_lease import ScreenAwakeLease
 from artemis.runtime.awake_service import _run_awake_adb_command
 from artemis.utils.logger import get_logger
+from mcp_server.notifiers.agentapi import AgentApiNotifier
+from mcp_server.notifiers.desktop import (
+    DesktopNotifier,
+    escape_applescript_string,
+    escape_powershell_string,
+)
+from mcp_server.notifiers.script import ScriptNotifier
 from mcp_server.utils import device_utils, env_utils
 
 
@@ -156,7 +163,10 @@ def test_mcp_stdio_handshake_immediate_input():
 
 def test_awake_service_adb_command_isolates_stdin():
     """Verify _run_awake_adb_command always sets stdin=subprocess.DEVNULL."""
-    with patch("artemis.runtime.awake_service.subprocess.run") as mock_run:
+    with (
+        patch("artemis.runtime.adb_endpoint.toolchain.resolve", return_value="/mock/adb"),
+        patch("artemis.runtime.awake_service.subprocess.run") as mock_run,
+    ):
         mock_run.return_value = MagicMock(returncode=0, stdout="ok", stderr="")
         _run_awake_adb_command("test-dev-1", ["shell", "date"], "test command")
 
@@ -170,7 +180,10 @@ def test_awake_service_adb_command_isolates_stdin():
 def test_awake_lease_run_isolates_stdin():
     """Verify ScreenAwakeLease._run always sets stdin=subprocess.DEVNULL."""
     lease = ScreenAwakeLease("test-dev-1")
-    with patch("artemis.runtime.awake_lease.subprocess.run") as mock_run:
+    with (
+        patch("artemis.runtime.adb_endpoint.toolchain.resolve", return_value="/mock/adb"),
+        patch("artemis.runtime.awake_lease.subprocess.run") as mock_run,
+    ):
         mock_run.return_value = MagicMock(returncode=0, stdout="ok", stderr="")
         lease._run(["shell", "date"], "test lease command")
 
@@ -203,12 +216,125 @@ def test_device_utils_isolates_stdin():
 def test_ui_automator_client_isolates_stdin():
     """Verify ui_automator_client screencap commands isolate stdin."""
     client = ui_automator_client.UIAutomatorClient("dev-1")
-    with patch("artemis.clients.ui_automator_client.subprocess.run") as mock_run:
+    with (
+        patch(
+            "artemis.clients.ui_automator_client.adb_command", return_value=["adb", "-s", "dev-1"]
+        ),
+        patch("artemis.clients.ui_automator_client.subprocess.run") as mock_run,
+    ):
         mock_run.return_value = MagicMock(returncode=0, stdout=b"", stderr="")
         with patch("artemis.clients.ui_automator_client.Image.open"):
             client.get_screenshot()
         assert mock_run.called
         assert mock_run.call_args.kwargs.get("stdin") == subprocess.DEVNULL
+
+
+def test_agentapi_notifier_isolates_stdin():
+    """Verify AgentApiNotifier subprocess calls always set stdin=subprocess.DEVNULL."""
+    notifier = AgentApiNotifier()
+    with (
+        patch.object(notifier, "_find_agentapi_path", return_value="/usr/local/bin/agentapi"),
+        patch.object(
+            notifier, "_get_candidate_envs", return_value=[("127.0.0.1:1234", "dummy_token")]
+        ),
+        patch.object(notifier, "_save_shared_env"),
+        patch("mcp_server.notifiers.agentapi.subprocess.run") as mock_run,
+    ):
+        mock_run.return_value = MagicMock(returncode=0, stdout="{}", stderr="")
+        res = notifier.notify("test-conv-id", "Hello from Artemis", title="Test Header")
+        assert res is True
+        assert mock_run.called
+        assert mock_run.call_args.kwargs.get("stdin") == subprocess.DEVNULL
+
+
+def test_desktop_notifier_isolates_stdin_linux():
+    """Verify DesktopNotifier on Linux sets stdin=subprocess.DEVNULL."""
+    notifier = DesktopNotifier()
+    with (
+        patch("mcp_server.notifiers.desktop.os.getenv", return_value="1"),
+        patch("mcp_server.notifiers.desktop.sys.platform", "linux"),
+        patch("mcp_server.notifiers.desktop.shutil.which", return_value="/usr/bin/notify-send"),
+        patch("mcp_server.notifiers.desktop.subprocess.run") as mock_run,
+    ):
+        mock_run.return_value = MagicMock(returncode=0)
+        res = notifier.notify("cid", "Hello Linux", title="Test Linux")
+        assert res is True
+        assert mock_run.called
+        assert mock_run.call_args.kwargs.get("stdin") == subprocess.DEVNULL
+
+
+def test_desktop_notifier_isolates_stdin_darwin():
+    """Verify DesktopNotifier on macOS sets stdin=subprocess.DEVNULL and invokes osascript."""
+    notifier = DesktopNotifier()
+    with (
+        patch("mcp_server.notifiers.desktop.os.getenv", return_value="1"),
+        patch("mcp_server.notifiers.desktop.sys.platform", "darwin"),
+        patch("mcp_server.notifiers.desktop.shutil.which", return_value="/usr/bin/osascript"),
+        patch("mcp_server.notifiers.desktop.subprocess.run") as mock_run,
+    ):
+        mock_run.return_value = MagicMock(returncode=0)
+        res = notifier.notify(
+            "cid", 'Notification with "quotes" and \\backslashes\\', title="macOS Title"
+        )
+        assert res is True
+        assert mock_run.called
+        assert mock_run.call_args.kwargs.get("stdin") == subprocess.DEVNULL
+        # Verify script escaping in command arguments
+        cmd = mock_run.call_args.args[0]
+        assert cmd[0] == "osascript"
+        assert cmd[1] == "-e"
+        assert '\\"quotes\\"' in cmd[2]
+        assert "\\\\backslashes\\\\" in cmd[2]
+
+
+def test_desktop_notifier_isolates_stdin_windows():
+    """Verify DesktopNotifier on Windows sets stdin=subprocess.DEVNULL."""
+    notifier = DesktopNotifier()
+    with (
+        patch("mcp_server.notifiers.desktop.os.getenv", return_value="1"),
+        patch("mcp_server.notifiers.desktop.sys.platform", "win32"),
+        patch("mcp_server.notifiers.desktop.subprocess.run") as mock_run,
+    ):
+        mock_run.return_value = MagicMock(returncode=0)
+        res = notifier.notify("cid", "Hello Windows", title="Test Windows")
+        assert res is True
+        assert mock_run.called
+        assert mock_run.call_args.kwargs.get("stdin") == subprocess.DEVNULL
+
+
+def test_script_notifier_isolates_stdin():
+    """Verify ScriptNotifier executes commands with stdin=subprocess.DEVNULL."""
+    notifier = ScriptNotifier()
+    with (
+        patch.object(notifier, "_get_command_template", return_value="echo {message}"),
+        patch("mcp_server.notifiers.script.subprocess.run") as mock_run,
+    ):
+        mock_run.return_value = MagicMock(returncode=0)
+        res = notifier.notify("cid", "Hello Script")
+        assert res is True
+        assert mock_run.called
+        assert mock_run.call_args.kwargs.get("stdin") == subprocess.DEVNULL
+
+
+def test_escape_applescript_string():
+    """Verify AppleScript string sanitization preserves apostrophes, escapes quotes and backslashes, and normalizes newlines."""
+    # Quotes and backslashes
+    assert escape_applescript_string('Hello "World" \\ Path') == 'Hello \\"World\\" \\\\ Path'
+    # Apostrophes should NOT be touched (valid in AppleScript double-quoted string literals)
+    assert escape_applescript_string("It's a test") == "It's a test"
+    # Newlines normalized to spaces to prevent syntax breakage
+    assert (
+        escape_applescript_string("Line 1\r\nLine 2\nLine 3\rLine 4")
+        == "Line 1 Line 2 Line 3 Line 4"
+    )
+    # Unicode preserved
+    assert escape_applescript_string("☕ Artemis 🚀") == "☕ Artemis 🚀"
+
+
+def test_escape_powershell_string():
+    """Verify PowerShell string sanitization escapes quotes and backticks, and normalizes newlines."""
+    assert escape_powershell_string('Hello "World" ` Path') == 'Hello `"World`" `` Path'
+    assert escape_powershell_string("Line 1\r\nLine 2\nLine 3") == "Line 1 Line 2 Line 3"
 
 
 def test_logger_header_does_not_pollute_stdout():

--- a/tests/unit/mcp/test_notifiers.py
+++ b/tests/unit/mcp/test_notifiers.py
@@ -217,7 +217,8 @@ def test_agentapi_notifier_candidate_recovery_and_retry(monkeypatch, tmp_path):
 
     calls = []
 
-    def mock_run(cmd, capture_output, text, check, timeout, env):
+    def mock_run(cmd, capture_output=True, text=True, check=True, timeout=10, env=None, **kwargs):
+        env = env or {}
         calls.append(env.get("ANTIGRAVITY_LS_ADDRESS"))
         if env.get("ANTIGRAVITY_LS_ADDRESS") == "localhost:9999":
             raise subprocess.CalledProcessError(1, cmd)


### PR DESCRIPTION
## Summary

When Artemis runs as an MCP stdio server (e.g. within Antigravity, Cursor, or Claude Desktop), child subprocesses spawned without `stdin=subprocess.DEVNULL` can inherit the parent process's MCP stdio stream, creating a risk of protocol interference or channel stalls if a subprocess interacts with standard input.

Additionally, desktop notifications on macOS via `osascript` constructed inline AppleScript strings using raw f-strings. If a message or title contained double quotes (`"`), backslashes (`\\`), or newlines, `osascript` failed with AppleScript syntax errors (such as error `-2740`), causing notifications to be dropped.

This PR addresses both areas:
1. **Notifier Subprocess Stdio Isolation**: Sets `stdin=subprocess.DEVNULL` across all `subprocess.run` invocations in `AgentApiNotifier`, `DesktopNotifier` (Linux, macOS, and Windows notification commands), and `ScriptNotifier`, ensuring compatibility with existing stdout/stderr behavior while isolating standard input.
2. **AppleScript & PowerShell String Sanitization**: Introduces helper functions `escape_applescript_string` and `escape_powershell_string` in `mcp_server/notifiers/desktop.py` to safely escape quotes and backslashes and normalize newlines into spaces while preserving apostrophes and Unicode.
3. **Unit & Regression Testing**: Expands `tests/unit/mcp/test_mcp_stdio_lifecycle.py` with tests verifying stdin isolation across `AgentApiNotifier`, `DesktopNotifier` (on Linux, Darwin, and Windows), and `ScriptNotifier`, alongside string sanitization tests.

## Changes
- `mcp_server/notifiers/agentapi.py`: Added `stdin=subprocess.DEVNULL` to both `subprocess.run` invocations.
- `mcp_server/notifiers/desktop.py`: Added `escape_applescript_string` and `escape_powershell_string`; added `stdin=subprocess.DEVNULL` to `notify-send`, `osascript`, and `powershell` subprocess calls.
- `mcp_server/notifiers/script.py`: Added `stdin=subprocess.DEVNULL` to custom script runner `subprocess.run`.
- `tests/unit/mcp/test_mcp_stdio_lifecycle.py`: Added regression test coverage for stdin isolation and string escaping, and hermetic adb mocks.
- `tests/unit/mcp/test_notifiers.py`: Updated `mock_run` signature in `test_agentapi_notifier_candidate_recovery_and_retry` to accept `**kwargs` / `stdin`.

## Validation Performed
- `uv run pytest -v tests/unit/mcp/test_mcp_stdio_lifecycle.py` (14/14 passed)
- `uv run pytest -v tests/unit/mcp` (228 passed, 1 skipped)
- `uv run ruff check mcp_server/notifiers tests/unit/mcp` (All checks passed)
- `uv run ruff format --check mcp_server/notifiers tests/unit/mcp/test_mcp_stdio_lifecycle.py tests/unit/mcp/test_notifiers.py` (Clean)
- `uv run pyright --project pyright-core.json` (0 errors, 0 warnings)