### PR TITLE
test(runtime): isolate adb requirement and harden device lock FIFO test cleanup

### DIFF
--- a/tests/unit/core/test_diagnostics.py
+++ b/tests/unit/core/test_diagnostics.py
@@ -310,6 +310,10 @@ async def test_submission_probe_falls_back_to_unlocked_device(monkeypatch):
     """When the first device is locked but a second device is unlocked, submission probe falls back."""
     probe = AdbDeviceProbe()
     monkeypatch.setattr(
+        "artemis.core.diagnostics.probes.adb_probe.toolchain.resolve",
+        lambda name: "adb",
+    )
+    monkeypatch.setattr(
         probe,
         "_get_device_states",
         AsyncMock(return_value=[("device-locked", "device"), ("device-unlocked", "device")]),

--- a/tests/unit/runtime/test_awake_service.py
+++ b/tests/unit/runtime/test_awake_service.py
@@ -13,9 +13,10 @@ def completed(stdout="", returncode=0, stderr=""):
     return MagicMock(returncode=returncode, stdout=stdout, stderr=stderr)
 
 
+@patch("artemis.runtime.adb_endpoint.toolchain.resolve", return_value="/mock/adb")
 @patch("artemis.runtime.awake_service.ScreenAwakeLease")
 @patch("artemis.runtime.awake_service.subprocess.run")
-def test_usb_policy_is_primary_when_android_reports_it_active(mock_run, lease_type):
+def test_usb_policy_is_primary_when_android_reports_it_active(mock_run, lease_type, _mock_resolve):
     mock_run.side_effect = [
         completed(),
         completed(),
@@ -37,9 +38,12 @@ def test_usb_policy_is_primary_when_android_reports_it_active(mock_run, lease_ty
     assert not any("KEYCODE_UNKNOWN" in command for command in commands)
 
 
+@patch("artemis.runtime.adb_endpoint.toolchain.resolve", return_value="/mock/adb")
 @patch("artemis.runtime.awake_service.ScreenAwakeLease")
 @patch("artemis.runtime.awake_service.subprocess.run")
-def test_inactive_usb_policy_falls_back_to_effective_host_heartbeat(mock_run, _lease_type):
+def test_inactive_usb_policy_falls_back_to_effective_host_heartbeat(
+    mock_run, _lease_type, _mock_resolve
+):
     mock_run.side_effect = [
         completed(),
         completed(),

--- a/tests/unit/runtime/test_device_lock.py
+++ b/tests/unit/runtime/test_device_lock.py
@@ -150,15 +150,24 @@ def test_device_lock_waits_and_runs_next_owner_in_fifo_order():
         second.acquire()
         acquired.set()
 
-    thread = threading.Thread(target=acquire_second)
-    thread.start()
-    time.sleep(0.15)
-    assert not acquired.is_set()
+    thread = threading.Thread(target=acquire_second, daemon=True)
+    try:
+        thread.start()
+        time.sleep(0.15)
+        assert not acquired.is_set()
 
-    first.release()
-    assert acquired.wait(timeout=2.0)
-    second.release()
-    thread.join(timeout=2.0)
+        first.release()
+        assert acquired.wait(timeout=2.0)
+        second.release()
+        thread.join(timeout=2.0)
+    finally:
+        for lock in (first, second):
+            if lock._acquired:
+                try:
+                    lock.release()
+                except Exception:
+                    pass
+        thread.join(timeout=1.0)
 
 
 def test_submission_reservations_preserve_order_before_workers_start():
@@ -171,18 +180,29 @@ def test_submission_reservations_preserve_order_before_workers_start():
         second.acquire()
         second_acquired.set()
 
-    thread = threading.Thread(target=acquire_second)
-    thread.start()
-    time.sleep(0.15)
-    assert not second_acquired.is_set()
-
+    thread = threading.Thread(target=acquire_second, daemon=True)
     first = DeviceExecutionLock("emulator-5554", "first task", first_ticket)
-    first.acquire()
-    first.release()
+    try:
+        thread.start()
+        time.sleep(0.15)
+        assert not second_acquired.is_set()
 
-    assert second_acquired.wait(timeout=2.0)
-    second.release()
-    thread.join(timeout=2.0)
+        first.acquire()
+        first.release()
+
+        assert second_acquired.wait(timeout=2.0)
+        second.release()
+        thread.join(timeout=2.0)
+    finally:
+        for lock in (first, second):
+            if lock._acquired:
+                try:
+                    lock.release()
+                except Exception:
+                    pass
+        DeviceExecutionLock.cancel_reservation(first_ticket)
+        DeviceExecutionLock.cancel_reservation(second_ticket)
+        thread.join(timeout=1.0)
 
 
 def test_pending_reservation_at_queue_head_does_not_block_other_devices():
@@ -223,36 +243,55 @@ def test_pending_reservation_is_served_with_original_fifo_position_after_claim()
     order = []
     claimed_acquired = threading.Event()
     youngest_acquired = threading.Event()
+    cancel_event = threading.Event()
 
     def run_claimed():
-        claimed.acquire()
-        order.append("claimed")
-        claimed_acquired.set()
+        try:
+            claimed.acquire(cancel_event=cancel_event)
+            order.append("claimed")
+            claimed_acquired.set()
+        except Exception:
+            pass
 
     def run_youngest():
-        youngest.acquire()
-        order.append("youngest")
-        youngest_acquired.set()
+        try:
+            youngest.acquire(cancel_event=cancel_event)
+            order.append("youngest")
+            youngest_acquired.set()
+        except Exception:
+            pass
 
-    t1 = threading.Thread(target=run_claimed)
-    t2 = threading.Thread(target=run_youngest)
+    t1 = threading.Thread(target=run_claimed, daemon=True)
+    t2 = threading.Thread(target=run_youngest, daemon=True)
     t1.start()
     t2.start()
-    time.sleep(0.2)
-    assert not claimed_acquired.is_set()
-    assert not youngest_acquired.is_set()
+    try:
+        time.sleep(0.2)
+        assert not claimed_acquired.is_set()
+        assert not youngest_acquired.is_set()
 
-    holder.release()
-    # The claimed pending ticket kept its original (oldest) FIFO timestamp and
-    # must win the device before the younger concrete ticket.
-    assert claimed_acquired.wait(timeout=2.0)
-    assert not youngest_acquired.is_set()
-    claimed.release()
-    assert youngest_acquired.wait(timeout=2.0)
-    youngest.release()
-    t1.join(timeout=2.0)
-    t2.join(timeout=2.0)
-    assert order == ["claimed", "youngest"]
+        holder.release()
+        # The claimed pending ticket kept its original (oldest) FIFO timestamp and
+        # must win the device before the younger concrete ticket.
+        assert claimed_acquired.wait(timeout=2.0)
+        assert not youngest_acquired.is_set()
+        claimed.release()
+        assert youngest_acquired.wait(timeout=2.0)
+        youngest.release()
+        t1.join(timeout=2.0)
+        t2.join(timeout=2.0)
+        assert order == ["claimed", "youngest"]
+    finally:
+        cancel_event.set()
+        for lock in (holder, claimed, youngest):
+            if lock._acquired:
+                try:
+                    lock.release()
+                except Exception:
+                    pass
+        DeviceExecutionLock.cancel_reservation(first_ticket)
+        t1.join(timeout=1.0)
+        t2.join(timeout=1.0)
 
 
 def test_cancelled_reservation_cannot_execute():
@@ -282,23 +321,28 @@ def test_waiting_acquire_can_be_cancelled_without_leaving_a_ticket():
     errors = []
     owner.acquire()
 
-    def wait_for_device():
-        try:
-            waiter.acquire(cancel_event=cancel_event)
-        except DeviceBusyError as exc:
-            errors.append(str(exc))
-
-    thread = threading.Thread(target=wait_for_device)
-    thread.start()
-    time.sleep(0.15)
-    cancel_event.set()
-    thread.join(timeout=2.0)
-
     try:
+
+        def wait_for_device():
+            try:
+                waiter.acquire(cancel_event=cancel_event)
+            except DeviceBusyError as exc:
+                errors.append(str(exc))
+
+        thread = threading.Thread(target=wait_for_device, daemon=True)
+        thread.start()
+        time.sleep(0.15)
+        cancel_event.set()
+        thread.join(timeout=2.0)
+
         assert errors == ["Waiting for the Artemis device queue was cancelled."]
         assert list(waiter.queue_dir.glob("*.wait")) == []
     finally:
-        owner.release()
+        if owner._acquired:
+            try:
+                owner.release()
+            except Exception:
+                pass
 
 
 def test_active_owner_is_discoverable_and_can_be_annotated(monkeypatch):


### PR DESCRIPTION
## Summary

Per `CONTRIBUTING.md`, the unit test suite (`make test`) should run deterministically and hermetically without requiring an Android device, model credentials, or host-installed external dependencies.

Two categories of test reliability issues were addressed:
1. **Host ADB Dependency in Unit Tests**:
   - `tests/unit/runtime/test_awake_service.py` (`test_usb_policy_is_primary_when_android_reports_it_active` and `test_inactive_usb_policy_falls_back_to_effective_host_heartbeat`) mocked `subprocess.run` but not `toolchain.resolve("adb")`. On environments without the Android SDK / `adb` on `PATH`, `AdbSession.command()` raised `FileNotFoundError`, causing `_run_command()` to swallow the error and bypass `subprocess.run`, failing the tests.
   - `tests/unit/core/test_diagnostics.py` (`test_submission_probe_falls_back_to_unlocked_device`) omitted mocking `toolchain.resolve("adb")`, causing `probe_submission_readiness` to fail immediately with `"ADB Not Found"` when `adb` is missing from the host.
2. **Device Lock FIFO Test Thread Cleanup (Related to #44)**:
   - In `tests/unit/runtime/test_device_lock.py` (`test_pending_reservation_is_served_with_original_fifo_position_after_claim`), this hardens a failure mode observed in #44: worker threads were previously created without `daemon=True` and executed without `try...finally` resource cleanup. If an assertion timeout or error occurred, worker threads remained alive in their polling/acquire loops indefinitely, preventing pytest from exiting.

## Changes
- `tests/unit/runtime/test_awake_service.py`: Added `@patch("artemis.runtime.adb_endpoint.toolchain.resolve", return_value="/mock/adb")` to `test_usb_policy_is_primary_when_android_reports_it_active` and `test_inactive_usb_policy_falls_back_to_effective_host_heartbeat`.
- `tests/unit/core/test_diagnostics.py`: Added `monkeypatch.setattr("artemis.core.diagnostics.probes.adb_probe.toolchain.resolve", lambda name: "adb")` to `test_submission_probe_falls_back_to_unlocked_device`.
- `tests/unit/runtime/test_device_lock.py`:
  - Marked background test threads as `daemon=True`.
  - Added cancellation event signaling and structured `try...finally` blocks to guarantee that all acquired locks are released, pending reservations are cancelled, and threads terminate cleanly even on failure.

## Validation Performed
- `for i in {1..20}; do uv run pytest -q tests/unit/runtime/test_device_lock.py -k test_pending_reservation || break; done` (20 consecutive runs passed, 0 hangs)
- `uv run pytest -v tests/unit/runtime/test_device_lock.py` (17/17 passed)
- `uv run pytest -v tests/unit/runtime/test_awake_service.py` (9/9 passed)
- `uv run pytest -v tests/unit/core/test_diagnostics.py -k test_submission_probe_falls_back_to_unlocked_device` (1/1 passed)
- `uv run pytest -v tests/unit/runtime` (139/139 passed)
- `uv run ruff check tests/unit/runtime tests/unit/core/test_diagnostics.py` (All checks passed)
- `uv run ruff format --check tests/unit/runtime/test_awake_service.py tests/unit/core/test_diagnostics.py tests/unit/runtime/test_device_lock.py` (All files formatted)
- `uv run pyright --project pyright-core.json` (0 errors, 0 warnings)