### PR TITLE
test(mcp): isolate invalid action trace test

### DIFF
--- a/tests/unit/mcp/test_mcp_tools.py
+++ b/tests/unit/mcp/test_mcp_tools.py
@@ -370,7 +370,9 @@ async def test_mobile_get_device_state_hierarchy_without_ocr():
 
 
 @pytest.mark.asyncio
-async def test_mobile_inspect_trace_invalid_action():
+async def test_mobile_inspect_trace_invalid_action(temp_trace_env):
+    Path(temp_trace_env, "data_engine.db").touch()
+
     res = await mobile_inspect_trace(action="invalid_action", trace_id="trace-123")
     assert "error" in res
     assert "not supported" in res["message"]


### PR DESCRIPTION
Summary

Make "test_mobile_inspect_trace_invalid_action" deterministic by isolating it from local filesystem state.

Changes

- use the existing "temp_trace_env" fixture
- create an empty "data_engine.db" in the temporary trace directory before calling "mobile_inspect_trace"

This ensures the test consistently reaches the unsupported action path instead of depending on whether a local "traces/data_engine.db" already exists.

Fixes #62

Signed-off-by: Rohan Pattanayak