### PR TITLE
Fix test isolation for test_mobile_inspect_trace_invalid_action

### DIFF
--- a/tests/unit/mcp/test_mcp_tools.py
+++ b/tests/unit/mcp/test_mcp_tools.py
@@ -370,7 +370,14 @@ async def test_mobile_get_device_state_hierarchy_without_ocr():
 
 
 @pytest.mark.asyncio
-async def test_mobile_inspect_trace_invalid_action():
+async def test_mobile_inspect_trace_invalid_action(temp_trace_env):
+    # mobile_inspect_trace returns "Database not found" before it even looks at
+    # `action` if data_engine.db doesn't exist, so this needs an isolated trace
+    # env with the db file present to actually exercise the action-validation
+    # branch this test is meant to check.
+    db_path = os.path.join(temp_trace_env, "data_engine.db")
+    open(db_path, "a").close()
+
     res = await mobile_inspect_trace(action="invalid_action", trace_id="trace-123")
     assert "error" in res
     assert "not supported" in res["message"]


### PR DESCRIPTION
## Summary

`test_mobile_inspect_trace_invalid_action` didn't use the `temp_trace_env` fixture that every other test in this module uses, so it called `mobile_inspect_trace` against whatever `trace_store.TRACES_DIR` resolves to on the machine running the tests (defaulting to `<project_root>/traces`).

`mobile_inspect_trace` returns a "Database not found" error unconditionally when `data_engine.db` is missing there, before it even looks at the `action` argument. So the test's `action="invalid_action"` case never reached the "action not supported" branch it's meant to check:

- On a machine with a leftover `traces/data_engine.db` from an earlier run, the test passed by coincidence, without ever exercising the intended code path.
- On a clean checkout, the same test fails with an unrelated database error instead of the assertion it's written to check.

Fixes #62.

## Fix

Give the test its own isolated `trace_store.TRACES_DIR` via the existing `temp_trace_env` fixture, and create an empty `data_engine.db` in it — matching the pattern already used by the other tests in this file. `mobile_inspect_trace` never touches the database contents for an unsupported action string, so an empty file is enough to reach the actual validation branch.

## Test plan

- Confirmed the test fails on a clean checkout (no `traces/data_engine.db`) against the original test body, with the exact error from the issue: `AssertionError: assert 'not supported' in 'Data engine database does not exist at .../traces/data_engine.db yet.'`
- Confirmed the test passes with the fix.
- Ran the full `tests/unit/mcp/test_mcp_tools.py` suite (25 tests) on a clean `traces/` dir: all pass, no regressions.
