### PR TITLE
fix: prevent shell injection via package_name/url/key inputs

### DIFF
--- a/artemis/controllers/unified_controller.py
+++ b/artemis/controllers/unified_controller.py
@@ -29,6 +29,7 @@ from artemis.config.paths import get_temp_dir
 from artemis.context import ArtemisContext
 from artemis.drivers.factory import get_driver
 from artemis.drivers.base import BaseDeviceDriver
+from artemis.utils.android_validation import is_valid_package_name, quote_url_for_adb
 from artemis.controllers.device_controller import ScreenDataResponse
 from artemis.controllers.types import (
     SwipeRequest,
@@ -213,15 +214,39 @@ class UnifiedMobileController:
         return screen_data.screenshot_base64
 
     async def launch_app(self, package_or_bundle_id: str) -> bool:
-        return await self._driver.launch_app(package_or_bundle_id)
+        if not is_valid_package_name(
+            package_or_bundle_id.strip()
+            if isinstance(package_or_bundle_id, str)
+            else package_or_bundle_id
+        ):
+            logger.warning(f"Refusing launch_app with invalid package: {package_or_bundle_id!r}")
+            return False
+        return await self._driver.launch_app(package_or_bundle_id.strip())
 
     async def terminate_app(self, package_or_bundle_id: str | None) -> bool:
         if not package_or_bundle_id:
             return False
-        return await self._driver.stop_app(package_or_bundle_id)
+        if not is_valid_package_name(
+            package_or_bundle_id.strip()
+            if isinstance(package_or_bundle_id, str)
+            else package_or_bundle_id
+        ):
+            logger.warning(f"Refusing terminate_app with invalid package: {package_or_bundle_id!r}")
+            return False
+        return await self._driver.stop_app(package_or_bundle_id.strip())
 
     async def open_url(self, url: str) -> bool:
-        await self._driver.execute_shell(f"am start -a android.intent.action.VIEW -d '{url}'")
+        try:
+            quoted = quote_url_for_adb(url)
+        except ValueError as e:
+            logger.warning(f"Refusing open_url with invalid URL: {e}")
+            return False
+        result = await self._driver.execute_shell(
+            f"am start -a android.intent.action.VIEW -d {quoted}"
+        )
+        if isinstance(result, str) and result.startswith("Error:"):
+            logger.warning(f"open_url failed for {url!r}: {result}")
+            return False
         return True
 
     async def go_back(self) -> bool:

--- a/artemis/drivers/android/adb_driver.py
+++ b/artemis/drivers/android/adb_driver.py
@@ -28,6 +28,11 @@ from artemis.clients.ui_automator_client import (
 from artemis.config.paths import get_temp_dir
 from artemis.drivers.base import BaseDeviceDriver, KeyCode, ScreenData, SwipeDirection
 from artemis.toolchain import find_ffmpeg, find_scrcpy
+from artemis.utils.android_validation import (
+    coerce_coord,
+    coerce_keycode,
+    is_valid_package_name,
+)
 from artemis.utils.video import build_scrcpy_record_command
 from artemis.utils.ui_filter import filter_ui_hierarchy
 from artemis.utils.logger import get_logger
@@ -235,6 +240,12 @@ class AndroidAdbDriver(BaseDeviceDriver):
         delay_ms: int = 100,
     ) -> bool:
         try:
+            safe_x = coerce_coord(x)
+            safe_y = coerce_coord(y)
+            if safe_x is None or safe_y is None:
+                logger.warning(f"Refusing tap with non-integer coordinates: ({x!r}, {y!r})")
+                return False
+            x, y = safe_x, safe_y
             if duration_ms >= 500:
                 cmd = f"input swipe {x} {y} {x} {y} {duration_ms}"
             else:
@@ -263,6 +274,14 @@ class AndroidAdbDriver(BaseDeviceDriver):
         duration_ms: int = 800,
     ) -> bool:
         try:
+            coords = [coerce_coord(v) for v in (start_x, start_y, end_x, end_y)]
+            if any(v is None for v in coords):
+                logger.warning(
+                    "Refusing swipe with non-integer coordinates: "
+                    f"({start_x!r}, {start_y!r}) -> ({end_x!r}, {end_y!r})"
+                )
+                return False
+            start_x, start_y, end_x, end_y = coords  # type: ignore[misc]
             cmd = f"input swipe {start_x} {start_y} {end_x} {end_y} {duration_ms}"
             logger.info(f"[ADB] {cmd}")
             await asyncio.to_thread(self.device.shell, cmd)
@@ -371,10 +390,10 @@ class AndroidAdbDriver(BaseDeviceDriver):
 
     async def press_key(self, key: KeyCode | str | int) -> bool:
         try:
-            keycode_val = key
-            if isinstance(key, (KeyCode, str)):
-                key_name = str(key).lower().replace("keycode.", "")
-                keycode_val = ANDROID_KEYCODE_MAP.get(key_name, key)
+            keycode_val = coerce_keycode(key, ANDROID_KEYCODE_MAP)
+            if keycode_val is None:
+                logger.warning(f"Refusing press_key with unsafe key value: {key!r}")
+                return False
 
             await asyncio.to_thread(self.device.shell, f"input keyevent {keycode_val}")
             return True
@@ -384,7 +403,12 @@ class AndroidAdbDriver(BaseDeviceDriver):
 
     async def launch_app(self, package_name: str) -> bool:
         try:
-            cmd = f"monkey -p {package_name} -c android.intent.category.LAUNCHER 1"
+            if not is_valid_package_name(
+                package_name.strip() if isinstance(package_name, str) else package_name
+            ):
+                logger.warning(f"Refusing launch_app with invalid package name: {package_name!r}")
+                return False
+            cmd = f"monkey -p {package_name.strip()} -c android.intent.category.LAUNCHER 1"
             await asyncio.to_thread(self.device.shell, cmd)
             return True
         except Exception as e:
@@ -393,7 +417,12 @@ class AndroidAdbDriver(BaseDeviceDriver):
 
     async def stop_app(self, package_name: str) -> bool:
         try:
-            await asyncio.to_thread(self.device.shell, f"am force-stop {package_name}")
+            if not is_valid_package_name(
+                package_name.strip() if isinstance(package_name, str) else package_name
+            ):
+                logger.warning(f"Refusing stop_app with invalid package name: {package_name!r}")
+                return False
+            await asyncio.to_thread(self.device.shell, f"am force-stop {package_name.strip()}")
             return True
         except Exception as e:
             logger.error(f"Stop app failed for '{package_name}': {e}")

--- a/artemis/mcp/adb_server.py
+++ b/artemis/mcp/adb_server.py
@@ -43,6 +43,7 @@ from artemis.clients.screen_client_factory import create_screen_client
 from artemis.context import ArtemisContext, DeviceContext, DevicePlatform
 from artemis.controllers.unified_controller import UnifiedMobileController
 from artemis.platform import platform
+from artemis.utils.android_validation import is_valid_package_name, quote_url_for_adb
 from artemis.utils.app_launch_utils import launch_app_with_retries
 
 
@@ -299,30 +300,42 @@ async def back(ctx: Context) -> str:
 @mcp.tool()
 async def launch_app(ctx: Context, package_name: str) -> str:
     """Launches an application by its Android package name with retries and smart polling."""
+    if not is_valid_package_name(
+        package_name.strip() if isinstance(package_name, str) else package_name
+    ):
+        return f"Error: Invalid Android package name: {package_name!r}"
     try:
         controller = _get_controller()
     except Exception as e:
         return f"Error: Controller lazy initialization failed: {e}"
 
-    success, error_msg = await launch_app_with_retries(controller.ctx, package_name)
+    success, error_msg = await launch_app_with_retries(controller.ctx, package_name.strip())
     return "Success" if success else f"Failed: {error_msg}"
 
 
 @mcp.tool()
 async def stop_app(ctx: Context, package_name: str) -> str:
     """Force stops an application by its Android package name."""
+    if not is_valid_package_name(
+        package_name.strip() if isinstance(package_name, str) else package_name
+    ):
+        return f"Error: Invalid Android package name: {package_name!r}"
     try:
         controller = _get_controller()
     except Exception as e:
         return f"Error: Controller lazy initialization failed: {e}"
 
-    success = await controller.terminate_app(package_name)
+    success = await controller.terminate_app(package_name.strip())
     return "Success" if success else "Failed"
 
 
 @mcp.tool()
 async def open_link(ctx: Context, url: str) -> str:
     """Opens a URL or deep link on the device."""
+    try:
+        quote_url_for_adb(url)
+    except ValueError:
+        return f"Error: Invalid URL: {url!r}"
     try:
         controller = _get_controller()
     except Exception as e:

--- a/artemis/utils/android_validation.py
+++ b/artemis/utils/android_validation.py
@@ -1,0 +1,119 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Validation helpers for values interpolated into on-device shell commands.
+
+`adb shell "<cmd>"` is parsed by the device's own shell, so any shell
+metacharacters (``;``, ``&&``, ``$()``, backticks, ...) in interpolated
+values execute on the connected device. These helpers are the structural
+guard for the MCP -> controller -> driver path (issue #55).
+"""
+
+from __future__ import annotations
+
+import re
+import shlex
+
+# Android package-name grammar: at least two dot-separated components, each
+# starting with a letter followed by letters/digits/underscores.
+# See https://developer.android.com/build/configure-app-module#set-application-id
+PACKAGE_NAME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_]*(\.[A-Za-z][A-Za-z0-9_]*)+$")
+
+# Android keycodes are small non-negative integers (KEYCODE_* < ~300 today).
+# 1000 is a generous upper bound that still blocks arbitrary string injection.
+MAX_KEYCODE = 1000
+
+
+def is_valid_package_name(package_name: object) -> bool:
+    """Return True iff `package_name` matches Android's package-name grammar."""
+    if not isinstance(package_name, str):
+        return False
+    if len(package_name) > 255:
+        return False
+    return PACKAGE_NAME_RE.match(package_name) is not None
+
+
+def require_valid_package_name(package_name: str) -> str:
+    """Return stripped package name or raise ValueError if it is unsafe."""
+    if not is_valid_package_name(
+        package_name.strip() if isinstance(package_name, str) else package_name
+    ):
+        raise ValueError(f"Invalid Android package name: {package_name!r}")
+    return package_name.strip()
+
+
+def quote_url_for_adb(url: str) -> str:
+    """Quote `url` for safe interpolation into a single `adb shell` argument.
+
+    Uses `shlex.quote` (POSIX quoting understood by Android's shell) instead
+    of manual single-quote wrapping, which breaks on embedded quotes.
+    """
+    if not isinstance(url, str) or not url.strip():
+        raise ValueError(f"Invalid URL: {url!r}")
+    cleaned = url.strip()
+    if len(cleaned) > 4096:
+        raise ValueError(f"Invalid URL (too long): {cleaned[:64]!r}...")
+    if any(ord(ch) < 32 or ord(ch) == 127 for ch in cleaned):
+        raise ValueError(f"Invalid URL (control characters): {cleaned[:64]!r}")
+    return shlex.quote(cleaned)
+
+
+def coerce_keycode(key: object, keymap: dict[str, int]) -> int | None:
+    """Resolve user-supplied key to an integer keycode, or None if unsafe.
+
+    Accepts KeyCode enum members, known names (with or without KEYCODE_
+    prefix, case-insensitive), and plain integer strings/ints in range.
+    Anything else (e.g. "4; reboot") returns None instead of passing
+    through raw into `input keyevent`.
+    """
+    if hasattr(key, "value"):
+        try:
+            key = key.value  # type: ignore[assignment]
+        except Exception:
+            return None
+    if isinstance(key, bool):
+        return None
+    if isinstance(key, int):
+        return key if 0 <= key <= MAX_KEYCODE else None
+    if not isinstance(key, str):
+        return None
+    normalized = key.strip().lower().replace("keycode.", "").replace("keycode_", "")
+    if normalized in keymap:
+        return keymap[normalized]
+    # Bare integer strings such as "123" (KEYCODE_MOVE_END) are legitimate.
+    if re.fullmatch(r"\d{1,4}", normalized):
+        try:
+            value = int(normalized)
+        except ValueError:
+            return None
+        return value if 0 <= value <= MAX_KEYCODE else None
+    return None
+
+
+def coerce_coord(value: object) -> int | None:
+    """Coerce tap/swipe coordinate to int, or None if not a plain integer."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value) if value.is_integer() else None
+    if isinstance(value, str):
+        if re.fullmatch(r"-?\d+", value.strip()):
+            try:
+                return int(value.strip())
+            except ValueError:
+                return None
+        return None
+    return None

--- a/artemis/utils/app_launch_utils.py
+++ b/artemis/utils/app_launch_utils.py
@@ -28,6 +28,7 @@ from artemis.controllers.platform_specific_commands_controller import (
 )
 from artemis.controllers.unified_controller import UnifiedMobileController
 from artemis.data_engine.trace import TraceSpan
+from artemis.utils.android_validation import is_valid_package_name
 from artemis.utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -284,6 +285,13 @@ async def launch_app_with_retries(
     Returns:
         Tuple of (success: bool, error_message: str | None)
     """
+    if not is_valid_package_name(
+        app_package.strip() if isinstance(app_package, str) else app_package
+    ):
+        error_msg = f"Invalid Android package name: {app_package!r}"
+        logger.error(error_msg)
+        return False, error_msg
+    app_package = app_package.strip()
 
     for attempt in range(1, max_retries + 1):
         logger.info(f"Launch attempt {attempt}/{max_retries} for app {app_package}")

--- a/tests/unit/test_shell_injection.py
+++ b/tests/unit/test_shell_injection.py
@@ -1,0 +1,185 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for issue #55: shell injection via package_name/url/key."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from artemis.controllers.unified_controller import UnifiedMobileController
+from artemis.drivers.android.adb_driver import AndroidAdbDriver
+from artemis.drivers.base import KeyCode
+from artemis.utils.android_validation import (
+    coerce_coord,
+    coerce_keycode,
+    is_valid_package_name,
+    quote_url_for_adb,
+)
+from artemis.utils.app_launch_utils import launch_app_with_retries
+
+
+def _make_driver():
+    mock_adb_client = MagicMock()
+    mock_adb_device = MagicMock()
+    mock_adb_client.device.return_value = mock_adb_device
+    driver = AndroidAdbDriver(device_id="emulator-5554", adb_client=mock_adb_client)
+    return driver, mock_adb_device
+
+
+def _make_controller(mock_driver):
+    controller = UnifiedMobileController.__new__(UnifiedMobileController)
+    controller.ctx = MagicMock()
+    controller._driver = mock_driver
+    controller._segment_cache = {}
+    return controller
+
+
+def test_package_name_grammar():
+    assert is_valid_package_name("com.android.settings")
+    assert is_valid_package_name("com.example_app.Main")
+    assert not is_valid_package_name("com.android.settings; reboot")
+    assert not is_valid_package_name("com.x$(reboot)")
+    assert not is_valid_package_name("com.android.settings && reboot")
+    assert not is_valid_package_name("com.android.settings`reboot`")
+    assert not is_valid_package_name("")
+    assert not is_valid_package_name("singlecomponent")
+    assert not is_valid_package_name(None)
+    assert not is_valid_package_name(123)
+
+
+@pytest.mark.asyncio
+async def test_driver_launch_app_rejects_injection():
+    driver, device = _make_driver()
+    assert await driver.launch_app("com.android.settings; reboot") is False
+    assert await driver.launch_app("com.android.settings && reboot") is False
+    assert await driver.launch_app("com.x$(whoami)") is False
+    device.shell.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_driver_launch_app_accepts_valid():
+    driver, device = _make_driver()
+    assert await driver.launch_app("com.android.settings") is True
+    device.shell.assert_called_with(
+        "monkey -p com.android.settings -c android.intent.category.LAUNCHER 1"
+    )
+
+
+@pytest.mark.asyncio
+async def test_driver_stop_app_rejects_injection():
+    driver, device = _make_driver()
+    assert await driver.stop_app("com.android.settings; reboot") is False
+    device.shell.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_driver_stop_app_accepts_valid():
+    driver, device = _make_driver()
+    assert await driver.stop_app("com.android.settings") is True
+    device.shell.assert_called_with("am force-stop com.android.settings")
+
+
+@pytest.mark.asyncio
+async def test_driver_press_key_rejects_injection():
+    driver, device = _make_driver()
+    assert await driver.press_key("4; reboot") is False
+    assert await driver.press_key("ENTER; reboot") is False
+    assert await driver.press_key("$(reboot)") is False
+    device.shell.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_driver_press_key_accepts_known_and_numeric():
+    driver, device = _make_driver()
+    assert await driver.press_key(KeyCode.BACK) is True
+    device.shell.assert_called_with("input keyevent 4")
+    assert await driver.press_key("123") is True
+    device.shell.assert_called_with("input keyevent 123")
+    assert await driver.press_key("KEYCODE_ENTER") is True
+    device.shell.assert_called_with("input keyevent 66")
+
+
+def test_coerce_keycode_rejects_out_of_range():
+    from artemis.drivers.android.adb_driver import ANDROID_KEYCODE_MAP
+
+    assert coerce_keycode("4; reboot", ANDROID_KEYCODE_MAP) is None
+    assert coerce_keycode(99999, ANDROID_KEYCODE_MAP) is None
+    assert coerce_keycode("99999", ANDROID_KEYCODE_MAP) is None
+    assert coerce_keycode(True, ANDROID_KEYCODE_MAP) is None
+
+
+@pytest.mark.asyncio
+async def test_driver_tap_rejects_non_integer():
+    driver, device = _make_driver()
+    assert await driver.tap("540; reboot", 1200) is False  # type: ignore[arg-type]
+    device.shell.assert_not_called()
+    assert coerce_coord("540; reboot") is None
+    assert coerce_coord("540") == 540
+
+
+@pytest.mark.asyncio
+async def test_controller_open_url_quotes_single_quote():
+    mock_driver = AsyncMock()
+    mock_driver.execute_shell.return_value = "ok"
+    controller = _make_controller(mock_driver)
+    url = "http://x'; reboot; echo '"
+    assert await controller.open_url(url) is True
+    (cmd,), _ = mock_driver.execute_shell.call_args
+    # shlex.quote keeps it a single shell word: no unquoted command separator.
+    assert cmd.startswith("am start -a android.intent.action.VIEW -d ")
+    assert "; reboot;" not in cmd.replace("'; reboot; echo '", "QUOTED")
+    # The quoted payload must round-trip through POSIX shell parsing as one word.
+    import shlex as _shlex
+
+    words = _shlex.split(cmd)
+    assert url in words
+
+
+@pytest.mark.asyncio
+async def test_controller_open_url_rejects_invalid():
+    mock_driver = AsyncMock()
+    controller = _make_controller(mock_driver)
+    assert await controller.open_url("") is False
+    assert await controller.open_url("   ") is False
+    assert await controller.open_url("http://x\nreboot") is False
+    mock_driver.execute_shell.assert_not_called()
+
+
+def test_quote_url_rejects_control_chars():
+    with pytest.raises(ValueError):
+        quote_url_for_adb("")
+    with pytest.raises(ValueError):
+        quote_url_for_adb("http://x\nreboot")
+
+
+@pytest.mark.asyncio
+async def test_controller_launch_terminate_reject_invalid():
+    mock_driver = AsyncMock()
+    controller = _make_controller(mock_driver)
+    assert await controller.launch_app("com.android.settings; reboot") is False
+    assert await controller.terminate_app("com.android.settings; reboot") is False
+    mock_driver.launch_app.assert_not_called()
+    mock_driver.stop_app.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_launch_with_retries_rejects_invalid_without_controller():
+    with patch("artemis.utils.app_launch_utils.UnifiedMobileController") as mock_controller_cls:
+        success, error = await launch_app_with_retries(
+            ctx=MagicMock(), app_package="com.android.settings; reboot"
+        )
+        assert success is False
+        assert "Invalid Android package name" in (error or "")
+        mock_controller_cls.assert_not_called()


### PR DESCRIPTION
Fixes #55.

Shell metacharacters in MCP-supplied package_name/url/key reached `adb shell` unescaped (device-side shell parses them), allowing arbitrary on-device command execution, e.g. `launch_app('com.android.settings; reboot')` or `open_url("http://x'; reboot; echo '")`.

Changes:
- New `artemis/utils/android_validation.py`: package-name grammar check (`^[A-Za-z][A-Za-z0-9_]*(\.[A-Za-z][A-Za-z0-9_]*)+$`), `shlex.quote`-based URL quoting with control/length rejects, strict keycode (known names + 0-1000) and integer coord coercion.
- `AndroidAdbDriver`: validate in `launch_app/stop_app` (choke point), strict `press_key`/`tap`/`swipe`.
- `UnifiedMobileController`: defense-in-depth validation in `launch_app/terminate_app`, quoted `open_url` with error propagation.
- MCP `adb_server` tools (`launch_app/stop_app/open_link`) and `launch_app_with_retries`: early reject before any shell call.
- New `tests/unit/test_shell_injection.py` (14 tests).

Verification:
- `py_compile` clean, `ruff check` clean, `ruff format` applied.
- Isolated validation logic check passes (grammar, keycode, coord, shlex round-trip).
- Full `pytest`/`uv sync` not run (env sync times out on heavy deps in this environment).