### PR TITLE
fix: set analyzer clip output framerate to requested fps

### DIFF
--- a/artemis/utils/video.py
+++ b/artemis/utils/video.py
@@ -625,6 +625,8 @@ async def render_timeline_clip(
             ";".join(filter_parts),
             "-map",
             "[outv]",
+            "-r",
+            str(fps),
             "-c:v",
             "libx264",
             "-preset",


### PR DESCRIPTION
Fixes #52.

`render_timeline_clip()` set `fps={fps}` inside the ffmpeg filter graph but never set the output framerate, so ffmpeg fell back to its 25fps default and duplicated frames (77 instead of ~45 for a 3s window at 15fps), breaking the `frame_index / fps ~= recording_time` guarantee the function promises.

Change: pass `-r {fps}` to the output stage of the ffmpeg command.

Verification (per issue report): frame count drops 77 -> 46, within the test's expected 43-47 range; full `tests/unit/test_unified_controller_video.py` (22 tests) passes; `ruff format --check`, `ruff check`, and `pyright` clean on the changed file.