### PR TITLE
fix(sdk): dynamically resolve model and provider for connection pre-warming

### DIFF
--- a/artemis/sdk/agent.py
+++ b/artemis/sdk/agent.py
@@ -299,15 +299,33 @@ class Agent:
                 )
                 return
 
+            warmup_model = "gemini-3.8-flash"
+            is_google_provider = True
+            if hasattr(self, "_context") and self._context and hasattr(self._context, "llm_config"):
+                default_cfg = getattr(self._context.llm_config, "default", None)
+                if default_cfg:
+                    provider = getattr(default_cfg, "provider", "google")
+                    if isinstance(provider, str) and provider.lower() not in ("google", "gemini"):
+                        is_google_provider = False
+                    if getattr(default_cfg, "model", None):
+                        warmup_model = default_cfg.model
+
+            if not is_google_provider:
+                logger.info("Skipping Gemini pre-warming: non-Google provider configured.")
+                publish_startup_progress(
+                    "model_ready", "Model connection is ready", session_id=self._session_id
+                )
+                return
+
             # 1. Pre-warm Native SDK client
             client = genai.Client(api_key=key)
 
             # 2. Pre-warm LangChain client
-            chat = ChatGoogleGenerativeAI(model="gemini-3.8-flash", google_api_key=key)
+            chat = ChatGoogleGenerativeAI(model=warmup_model, google_api_key=key)
 
             # Fire both calls concurrently in the background
             await asyncio.gather(
-                client.aio.models.count_tokens(model="gemini-3.8-flash", contents="ping"),
+                client.aio.models.count_tokens(model=warmup_model, contents="ping"),
                 chat.ainvoke("ping"),
                 return_exceptions=True,
             )

--- a/tests/unit/sdk/test_agent_warmup.py
+++ b/tests/unit/sdk/test_agent_warmup.py
@@ -1,0 +1,133 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for ArtemisAgent connection pre-warming."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+import pytest
+
+from artemis.sdk.agent import Agent
+
+
+@pytest.fixture
+def mock_agent():
+    agent = Agent.__new__(Agent)
+    agent._session_id = "test-session-123"
+    agent._context = MagicMock()
+    return agent
+
+
+@pytest.mark.asyncio
+async def test_prewarm_uses_configured_google_model(mock_agent, monkeypatch):
+    """Verifies pre-warming uses the active configured model from llm_config."""
+    monkeypatch.delenv("ARTEMIS_FAKE_LLM", raising=False)
+    mock_agent._context.llm_config.default.provider = "google"
+    mock_agent._context.llm_config.default.model = "gemini-3.5-flash-lite"
+
+    mock_client = MagicMock()
+    mock_client.aio.models.count_tokens = AsyncMock(return_value=MagicMock())
+    mock_chat = MagicMock()
+    mock_chat.ainvoke = AsyncMock(return_value="pong")
+
+    with (
+        patch("artemis.sdk.agent.genai.Client", return_value=mock_client),
+        patch("artemis.sdk.agent.ChatGoogleGenerativeAI", return_value=mock_chat) as mock_chat_cls,
+        patch("artemis.sdk.agent.publish_startup_progress") as mock_progress,
+    ):
+        await mock_agent._prewarm_llm_connections(api_key="test-api-key")
+
+        mock_chat_cls.assert_called_once_with(
+            model="gemini-3.5-flash-lite", google_api_key="test-api-key"
+        )
+        mock_client.aio.models.count_tokens.assert_awaited_once_with(
+            model="gemini-3.5-flash-lite", contents="ping"
+        )
+        mock_chat.ainvoke.assert_awaited_once_with("ping")
+        assert mock_progress.call_count >= 2
+
+
+@pytest.mark.asyncio
+async def test_prewarm_skips_google_for_non_google_provider(mock_agent, monkeypatch):
+    """Verifies pre-warming skips Google GenAI calls if provider is openai or anthropic."""
+    monkeypatch.delenv("ARTEMIS_FAKE_LLM", raising=False)
+    mock_agent._context.llm_config.default.provider = "openai"
+    mock_agent._context.llm_config.default.model = "gpt-4o"
+
+    with (
+        patch("artemis.sdk.agent.genai.Client") as mock_client_cls,
+        patch("artemis.sdk.agent.ChatGoogleGenerativeAI") as mock_chat_cls,
+        patch("artemis.sdk.agent.publish_startup_progress") as mock_progress,
+    ):
+        await mock_agent._prewarm_llm_connections(api_key="test-api-key")
+
+        mock_client_cls.assert_not_called()
+        mock_chat_cls.assert_not_called()
+        mock_progress.assert_called_with(
+            "model_ready", "Model connection is ready", session_id="test-session-123"
+        )
+
+
+@pytest.mark.asyncio
+async def test_prewarm_skips_when_fake_llm_set(mock_agent, monkeypatch):
+    """Verifies ARTEMIS_FAKE_LLM=1 bypasses network pre-warming."""
+    monkeypatch.setenv("ARTEMIS_FAKE_LLM", "1")
+
+    with (
+        patch("artemis.sdk.agent.genai.Client") as mock_client_cls,
+        patch("artemis.sdk.agent.publish_startup_progress") as mock_progress,
+    ):
+        await mock_agent._prewarm_llm_connections(api_key="test-api-key")
+
+        mock_client_cls.assert_not_called()
+        mock_progress.assert_called_with(
+            "model_ready", "Model connection is ready (fake LLM)", session_id="test-session-123"
+        )
+
+
+@pytest.mark.asyncio
+async def test_prewarm_skips_gracefully_without_api_key(mock_agent, monkeypatch):
+    """Verifies pre-warming handles missing API key without raising exception."""
+    monkeypatch.delenv("ARTEMIS_FAKE_LLM", raising=False)
+    with (
+        patch("artemis.sdk.agent.settings") as mock_settings,
+        patch("artemis.sdk.agent.publish_startup_progress") as mock_progress,
+    ):
+        mock_settings.GOOGLE_API_KEY = None
+        await mock_agent._prewarm_llm_connections(api_key=None)
+
+        mock_progress.assert_called_with(
+            "model_ready",
+            "Model connection will initialize on first use",
+            session_id="test-session-123",
+        )
+
+
+@pytest.mark.asyncio
+async def test_prewarm_handles_network_failure_gracefully(mock_agent, monkeypatch):
+    """Verifies pre-warming handles network errors gracefully without crashing."""
+    monkeypatch.delenv("ARTEMIS_FAKE_LLM", raising=False)
+    mock_agent._context.llm_config.default.provider = "google"
+    mock_agent._context.llm_config.default.model = "gemini-3.8-flash"
+
+    with (
+        patch("artemis.sdk.agent.genai.Client", side_effect=RuntimeError("Network down")),
+        patch("artemis.sdk.agent.publish_startup_progress") as mock_progress,
+    ):
+        await mock_agent._prewarm_llm_connections(api_key="test-api-key")
+
+        mock_progress.assert_called_with(
+            "model_ready",
+            "Model connection will initialize on first use",
+            session_id="test-session-123",
+        )


### PR DESCRIPTION
### Summary

\_prewarm_llm_connections\ in \rtemis/sdk/agent.py\ previously hardcoded \gemini-3.8-flash\ for client warming regardless of what model or provider was configured in \AgentConfig\ / \config/artemis.jsonc\.

When a user selected a lightweight model (such as \gemini-3.5-flash-lite\) or an alternative provider (OpenAI, Anthropic, Ollama), this caused startup \429 RESOURCE_EXHAUSTED\ retries against exhausted tier quotas on \gemini-3.8-flash\.

### Key Changes
- **Dynamic Config Resolution**: Dynamically resolves \provider\ and \model\ from \self._context.llm_config.default\.
- **Provider Gate**: Gracefully skips Google GenAI connection warming when an alternative provider (OpenAI, Anthropic, Ollama, etc.) is configured.
- **Active Model Pre-warming**: Warms the active configured model rather than hardcoding \gemini-3.8-flash\.
- **Unit Tests**: Added 5 hermetic unit tests in \	ests/unit/sdk/test_agent_warmup.py\ covering:
  - Configured Google model
  - Non-Google provider skip
  - \ARTEMIS_FAKE_LLM=1\
  - Missing API key graceful skip
  - Transient network failure resilience

### Verification
- \uv run pytest tests/unit/sdk/test_agent_warmup.py -v\: 5 passed in 0.07s
- \uv run pytest tests/unit/sdk/ -v\: 29 passed in 0.66s
- \uv run ruff check artemis/sdk/agent.py tests/unit/sdk/test_agent_warmup.py\: All checks passed
- \uv run ruff format --check artemis/sdk/agent.py tests/unit/sdk/test_agent_warmup.py\: All checks passed