### PR TITLE
feat: support Anthropic Bearer gateways and per-node endpoint URLs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,13 @@ GEMINI_API_KEY=
 GOOGLE_API_KEY=
 OPENAI_API_KEY=
 ANTHROPIC_API_KEY=
+# Anthropic-compatible gateway (optional; e.g. a LiteLLM or corporate proxy).
+# ANTHROPIC_BASE_URL: leave empty to use the official api.anthropic.com.
+# ANTHROPIC_AUTH_TOKEN: sent as `Authorization: Bearer <token>` for gateways
+# that reject the SDK's default `x-api-key` header; overrides ANTHROPIC_API_KEY.
+# Omit /v1 from ANTHROPIC_BASE_URL; see docs/llm-gateways.md for examples.
+ANTHROPIC_BASE_URL=
+ANTHROPIC_AUTH_TOKEN=
 OPEN_ROUTER_API_KEY=
 XAI_API_KEY=
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,9 @@ uv run artemis mcp --install all
 
 ### 2. Manual Configuration (Optional)
 
+For Bearer-authenticated gateways and per-node model endpoints, see the short
+[LLM gateway configuration examples](./docs/llm-gateways.md).
+
 If you prefer to configure manually, run `uv run artemis mcp --generate-config <client>` (for example, `codex` or `antigravity`) to output the appropriate TOML or JSON snippet. Replace `/path/to/artemis` with your actual repo path and point `command` to your `.venv` Python executable:
 
 * **Codex** (`~/.codex/config.toml`):

--- a/artemis/config/llm.py
+++ b/artemis/config/llm.py
@@ -74,6 +74,22 @@ class LLM(BaseModel):
     model_config = {"ignored_types": (CyFunctionDetector,)}
     provider: LLMProvider
     model: str
+    # Per-endpoint base URL (jsonc key: "api_base"). Closes the gap where a
+    # custom endpoint (corporate gateway, LiteLLM proxy, local server) could
+    # only be configured process-wide through the protocol-scoped environment
+    # variables (OPENAI_BASE_URL / ANTHROPIC_BASE_URL): with this field two
+    # nodes can talk to two different endpoints in the same run — e.g. the
+    # planner through a corporate gateway while a util node uses the official
+    # API. Resolution order in ModelFactory:
+    #   endpoint.api_base  >  settings/env base URL  >  provider default.
+    # The value is provider-shaped, not host-shaped: the OpenAI driver expects
+    # the /v1 prefix in the URL while the Anthropic driver appends /v1/messages
+    # itself, so the same gateway host is spelled differently per provider —
+    # which is also why api_base must never survive a provider switch (see
+    # _drop_foreign_api_base below). Credentials deliberately stay OUT of this
+    # schema: keys and Bearer tokens belong in .env (ANTHROPIC_AUTH_TOKEN,
+    # OPENAI_API_KEY, ...), keeping model configs shareable and secret-free.
+    api_base: str | None = None
     temperature: float | None = None
     thinking_budget: int | None = None
     thinking_level: Literal["minimal", "low", "medium", "high"] | None = None
@@ -92,8 +108,22 @@ class LLM(BaseModel):
         elif self.provider == "vertexai":
             validate_vertex_ai_credentials()
         elif self.provider == "anthropic":
-            if not (settings.ANTHROPIC_API_KEY or os.environ.get("ANTHROPIC_API_KEY")):
-                raise Exception(f"{name} requires ANTHROPIC_API_KEY in .env")
+            # "anthropic" selects the wire protocol, not necessarily
+            # api.anthropic.com: Bearer-only gateways authenticate with
+            # ANTHROPIC_AUTH_TOKEN and never hold a real x-api-key, so
+            # requiring ANTHROPIC_API_KEY alone would reject valid gateway
+            # setups at startup and force users to mirror the token into
+            # ANTHROPIC_API_KEY as a workaround. Either credential satisfies
+            # this check; ModelFactory decides which one is actually sent.
+            if not (
+                settings.ANTHROPIC_API_KEY
+                or settings.get_anthropic_auth_token()
+                or os.environ.get("ANTHROPIC_API_KEY")
+            ):
+                raise Exception(
+                    f"{name} requires ANTHROPIC_API_KEY (or ANTHROPIC_AUTH_TOKEN"
+                    " for Bearer-only gateways) in .env"
+                )
         elif self.provider == "openrouter":
             if not settings.OPEN_ROUTER_API_KEY:
                 raise Exception(f"{name} requires OPEN_ROUTER_API_KEY in .env")
@@ -228,6 +258,25 @@ class LLMConfig(BaseModel):
         return value
 
 
+def _drop_foreign_api_base(cfg: dict, base: dict, override: dict) -> None:
+    """Drop an inherited ``api_base`` when the merged config switched provider.
+
+    ``api_base`` is provider-shaped (see the field's comment on :class:`LLM`),
+    so a node that overrides only ``provider``/``model`` must not inherit the
+    default's endpoint URL: a Google node under an Anthropic-gateway default
+    would otherwise aim its Gemini calls at the gateway. An ``api_base``
+    written explicitly in the node override always wins; the same rule is
+    applied one level down to the merged ``fallback`` dict.
+    """
+    if cfg.get("provider") != base.get("provider") and "api_base" not in override:
+        cfg.pop("api_base", None)
+    fb, fb_base = cfg.get("fallback"), base.get("fallback")
+    fb_override = override.get("fallback") or {}
+    if isinstance(fb, dict) and isinstance(fb_base, dict):
+        if fb.get("provider") != fb_base.get("provider") and "api_base" not in fb_override:
+            fb.pop("api_base", None)
+
+
 def _expand_default_into_nodes(config_dict: dict) -> dict:
     """Expand unified config format with 'default' and 'nodes' into full LLMConfig schema."""
     if "planner" in config_dict and "utils" in config_dict:
@@ -278,6 +327,7 @@ def _expand_default_into_nodes(config_dict: dict) -> dict:
                     node_cfg[k] = {**node_cfg[k], **v}
                 else:
                     node_cfg[k] = v
+        _drop_foreign_api_base(node_cfg, default_model_cfg, nodes_override.get(node, {}))
         result[node] = node_cfg
 
     utils_dict: dict[str, Any] = {}
@@ -289,6 +339,7 @@ def _expand_default_into_nodes(config_dict: dict) -> dict:
                     util_cfg[k] = {**util_cfg[k], **v}
                 else:
                     util_cfg[k] = v
+        _drop_foreign_api_base(util_cfg, default_model_cfg, nodes_override.get(util, {}))
         utils_dict[util] = util_cfg
     result["utils"] = utils_dict
 
@@ -336,11 +387,13 @@ def deep_merge_llm_config(base: LLMConfig, overrides: dict) -> LLMConfig:
     base_dict = base.model_dump()
 
     def merge(d1: dict, d2: dict) -> None:
+        previous = dict(d1)
         for k, v in d2.items():
             if k in d1 and isinstance(d1[k], dict) and isinstance(v, dict):
                 merge(d1[k], v)
             else:
                 d1[k] = v
+        _drop_foreign_api_base(d1, previous, d2)
 
     merge(base_dict, overrides)
     return LLMConfig.model_validate(base_dict)

--- a/artemis/config/settings.py
+++ b/artemis/config/settings.py
@@ -98,6 +98,9 @@ class Settings(BaseSettings):
     GEMINI_API_KEY: SecretStr | None = None
     GCP_API_KEY: SecretStr | None = None
     ANTHROPIC_API_KEY: SecretStr | None = None
+    # Bearer token for Anthropic-compatible gateways (LiteLLM, corporate
+    # proxies) that reject the SDK's default `x-api-key` header.
+    ANTHROPIC_AUTH_TOKEN: SecretStr | None = None
     XAI_API_KEY: SecretStr | None = None
     OPEN_ROUTER_API_KEY: SecretStr | None = None
 
@@ -106,8 +109,15 @@ class Settings(BaseSettings):
     VISION_API_KEY: SecretStr | None = None
     API_KEY: SecretStr | None = None
 
-    # Custom Provider Endpoints
+    # Custom Provider Endpoints — protocol-scoped defaults. The vendor prefix
+    # names which DRIVER reads the value, not who owns the server (an
+    # OpenAI-compatible or Anthropic-compatible gateway such as LiteLLM may
+    # serve any vendor's models). Per-endpoint "api_base" in the LLM config
+    # overrides these. The two drivers spell the same host differently:
+    # OPENAI_BASE_URL must include the /v1 prefix, ANTHROPIC_BASE_URL must
+    # not (the anthropic SDK appends /v1/messages itself).
     OPENAI_BASE_URL: str | None = None
+    ANTHROPIC_BASE_URL: str | None = None
 
     # Android ADB Connectivity
     ADB_HOST: str | None = Field(default=DEFAULT_ADB_HOST)
@@ -162,6 +172,7 @@ class Settings(BaseSettings):
             "GEMINI_API_KEY",
             "GCP_API_KEY",
             "ANTHROPIC_API_KEY",
+            "ANTHROPIC_AUTH_TOKEN",
             "XAI_API_KEY",
             "OPEN_ROUTER_API_KEY",
             "OCR_API_KEY",
@@ -182,6 +193,13 @@ class Settings(BaseSettings):
         if not self.OCR_API_KEY and self.VISION_API_KEY:
             self.OCR_API_KEY = self.VISION_API_KEY
         return self
+
+    def get_anthropic_auth_token(self) -> SecretStr | None:
+        """Resolve the gateway token without reviving sanitized placeholders."""
+        for token in (self.ANTHROPIC_AUTH_TOKEN, os.environ.get("ANTHROPIC_AUTH_TOKEN")):
+            if token and not is_placeholder_key(token):
+                return token if isinstance(token, SecretStr) else SecretStr(token)
+        return None
 
     def get_api_key(self, provider: str) -> SecretStr | None:
         """Get API key for a specified provider.

--- a/artemis/core/diagnostics/probes/credentials_probe.py
+++ b/artemis/core/diagnostics/probes/credentials_probe.py
@@ -54,6 +54,7 @@ class LLMCredentialsProbe(BaseProbe):
         gemini_key = settings.get_api_key("google")
         openai_key = settings.get_api_key("openai")
         claude_key = settings.get_api_key("anthropic")
+        anthropic_auth_token = settings.get_anthropic_auth_token()
         openrouter_key = settings.get_api_key("openrouter")
         xai_key = settings.get_api_key("xai")
         ocr_key = settings.get_api_key("ocr")
@@ -85,15 +86,25 @@ class LLMCredentialsProbe(BaseProbe):
                 }
             )
             api_keys_map["openai"] = o_val
-        if claude_key and not is_placeholder_key(claude_key):
-            c_val = claude_key.get_secret_value()
+        # Use the same token-over-key precedence as ModelFactory, and carry
+        # the destination/auth mode through to live credential verification.
+        anthropic_credential = anthropic_auth_token or claude_key
+        if anthropic_credential:
+            c_val = anthropic_credential.get_secret_value()
             configured_providers.append(
                 {
                     "provider": "anthropic",
-                    "label": "Claude",
+                    "label": "Anthropic-Compatible Gateway" if anthropic_auth_token else "Claude",
                     "masked": self._mask_key(c_val),
                     "raw_key": c_val,
                     "key": c_val,
+                    "base_url": (
+                        settings.ANTHROPIC_BASE_URL
+                        or os.environ.get("ANTHROPIC_BASE_URL")
+                        or os.environ.get("ANTHROPIC_API_URL")
+                        or "https://api.anthropic.com"
+                    ),
+                    "auth_mode": "bearer" if anthropic_auth_token else "api_key",
                 }
             )
             api_keys_map["anthropic"] = c_val
@@ -212,7 +223,7 @@ class LLMCredentialsProbe(BaseProbe):
             status=ProbeStatus.FAIL,
             is_blocker=self.is_blocker,
             summary="Key Missing",
-            description="No Multimodal LLM credential (e.g. GEMINI_API_KEY, OPENAI_API_KEY, ANTHROPIC_API_KEY) found in environment or .env file.",
+            description="No Multimodal LLM credential (e.g. GEMINI_API_KEY, OPENAI_API_KEY, ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN) found in environment or .env file.",
             metadata=metadata,
             actions=[
                 ProbeAction(

--- a/artemis/llm/anthropic_gateway.py
+++ b/artemis/llm/anthropic_gateway.py
@@ -1,0 +1,43 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Anthropic gateway authentication at the LangChain/SDK boundary."""
+
+from functools import cached_property
+from typing import Any
+
+from langchain_anthropic import ChatAnthropic
+from pydantic import Field, SecretStr
+
+
+class BearerChatAnthropic(ChatAnthropic):
+    """Pass a native Bearer credential to both SDK clients without an API key."""
+
+    auth_token: SecretStr = Field(exclude=True, repr=False)
+
+    @property
+    def lc_secrets(self) -> dict[str, str]:
+        return {**super().lc_secrets, "auth_token": "ANTHROPIC_AUTH_TOKEN"}
+
+    @cached_property
+    def _client_params(self) -> dict[str, Any]:
+        # ChatAnthropic has no public auth_token field and always passes an
+        # api_key (even an empty one). Adding Authorization to default_headers
+        # leaves X-Api-Key intact. Adapt the shared sync/async SDK parameters
+        # so the explicit token prevents credential lookup from the environment.
+        return {
+            **super()._client_params,
+            "api_key": None,
+            "auth_token": self.auth_token.get_secret_value(),
+        }

--- a/artemis/llm/router.py
+++ b/artemis/llm/router.py
@@ -306,21 +306,46 @@ class ModelFactory:
         elif provider == ModelProvider.ANTHROPIC:
             from langchain_anthropic import ChatAnthropic
 
-            api_key = (
-                endpoint.api_key
-                or (
-                    settings.ANTHROPIC_API_KEY.get_secret_value()
-                    if settings.ANTHROPIC_API_KEY
-                    else None
-                )
-                or os.environ.get("ANTHROPIC_API_KEY")
+            # "Anthropic" names the wire protocol, not the vendor: the target
+            # may be api.anthropic.com or any Anthropic-compatible gateway
+            # (LiteLLM, corporate proxies) serving arbitrary models — Claude
+            # or otherwise — under admin-defined, dynamic route aliases.
+            # Base URL resolution: per-endpoint api_base (LLM config) >
+            # ANTHROPIC_BASE_URL (settings/env; the SDK-standard name; do NOT
+            # include /v1 — the SDK appends /v1/messages itself, unlike the
+            # OpenAI driver whose base URL carries the /v1 prefix) > the SDK's
+            # api.anthropic.com default (base_url=None is filtered out below).
+            base_url = (
+                endpoint.api_base
+                or settings.ANTHROPIC_BASE_URL
+                or os.environ.get("ANTHROPIC_BASE_URL")
             )
+            auth_token = settings.get_anthropic_auth_token()
+            model_class = ChatAnthropic
             kwargs = {
                 "model": endpoint.model_name,
                 "temperature": endpoint.temperature,
-                "api_key": api_key,
                 "timeout": endpoint.timeout_seconds,
+                "base_url": base_url,
             }
+            if auth_token and not endpoint.api_key:
+                from artemis.llm.anthropic_gateway import BearerChatAnthropic
+
+                # Scoped API keys win over the global token; otherwise use
+                # native SDK Bearer auth, with no X-Api-Key header at all.
+                model_class = BearerChatAnthropic
+                kwargs["auth_token"] = auth_token
+                kwargs["api_key"] = ""  # Prevent LangChain's env-key lookup.
+            else:
+                kwargs["api_key"] = (
+                    endpoint.api_key
+                    or (
+                        settings.ANTHROPIC_API_KEY.get_secret_value()
+                        if settings.ANTHROPIC_API_KEY
+                        else None
+                    )
+                    or os.environ.get("ANTHROPIC_API_KEY")
+                )
             budget = endpoint.thinking_budget
             if not budget and endpoint.reasoning_effort:
                 effort_map = {"low": 2048, "medium": 8192, "high": 32768}
@@ -328,7 +353,7 @@ class ModelFactory:
             if budget:
                 kwargs["thinking"] = {"type": "enabled", "budget_tokens": budget}
                 kwargs["temperature"] = 1.0
-            return ChatAnthropic(**{k: v for k, v in kwargs.items() if v is not None})
+            return model_class(**{k: v for k, v in kwargs.items() if v is not None})
 
         elif provider == ModelProvider.OPENROUTER:
             from langchain_openai import ChatOpenAI

--- a/artemis/services/llm.py
+++ b/artemis/services/llm.py
@@ -1067,6 +1067,10 @@ def _resolve_endpoint(
     return ModelEndpoint(
         provider=ModelProvider.from_string(provider_val),
         model_name=str(model_val),
+        # Per-node endpoint override from the LLM config (jsonc "api_base");
+        # ModelFactory prefers it over the protocol-scoped env/settings base
+        # URLs, so different nodes may target different gateways in one run.
+        api_base=_get_val(cfg, "api_base", str),
         temperature=_get_val(cfg, "temperature", (int, float)) or 0.0,
         timeout_seconds=_get_val(cfg, "timeout", (int, float)) or 60.0,
         thinking_budget=_get_val(cfg, "thinking_budget", int),

--- a/artemis/utils/credentials_validator.py
+++ b/artemis/utils/credentials_validator.py
@@ -14,6 +14,8 @@
 
 """Validation utility to verify LLM and Vision API keys against live provider endpoints."""
 
+from typing import Literal
+
 import httpx
 
 from artemis.llm.google.provider import is_google_family_provider
@@ -61,6 +63,8 @@ async def validate_api_key(
     api_key: str,
     base_url: str | None = None,
     timeout: float = 12.0,
+    *,
+    auth_mode: Literal["api_key", "bearer"] = "api_key",
 ) -> tuple[bool, str]:
     """Tests if the provided API key is valid and usable with the corresponding provider.
 
@@ -69,6 +73,7 @@ async def validate_api_key(
         api_key: Secret API key string.
         base_url: Optional custom endpoint URL.
         timeout: Request timeout in seconds.
+        auth_mode: Anthropic authentication method; ignored by other providers.
 
     Returns:
         tuple[bool, str]: (is_valid, descriptive_message)
@@ -136,13 +141,15 @@ async def validate_api_key(
                 return False, f"OpenAI API verification failed ({resp.status_code}): {err_msg}"
 
             elif clean_provider in ("anthropic", "claude"):
-                url = "https://api.anthropic.com/v1/models"
+                url = f"{(base_url or 'https://api.anthropic.com').rstrip('/')}/v1/models"
+                headers = {"anthropic-version": "2023-06-01"}
+                if auth_mode == "bearer":
+                    headers["Authorization"] = f"Bearer {clean_key}"
+                else:
+                    headers["x-api-key"] = clean_key
                 resp = await client.get(
                     url,
-                    headers={
-                        "x-api-key": clean_key,
-                        "anthropic-version": "2023-06-01",
-                    },
+                    headers=headers,
                 )
                 if resp.status_code == 200:
                     return True, "Anthropic Claude API key verified successfully."

--- a/artemis/utils/file.py
+++ b/artemis/utils/file.py
@@ -18,9 +18,16 @@ from typing import IO
 
 
 def strip_json_comments(text: str) -> str:
-    text = re.sub(r"//.*?$", "", text, flags=re.MULTILINE)
-    text = re.sub(r"/\*.*?\*/", "", text, flags=re.DOTALL)
-    return text
+    """Remove comments while preserving JSON strings and source positions."""
+    # Consume strings first so URLs, escaped quotes and comment-like string
+    # values remain intact. Whitespace also prevents comments joining tokens.
+    pattern = r'"(?:\\.|[^"\\])*"|//[^\r\n]*|/\*.*?\*/'
+    return re.sub(
+        pattern,
+        lambda match: match[0] if match[0].startswith('"') else re.sub(r"[^\r\n]", " ", match[0]),
+        text,
+        flags=re.DOTALL,
+    )
 
 
 def load_jsonc(file: IO) -> dict:

--- a/config/examples/anthropic-gateway.jsonc
+++ b/config/examples/anthropic-gateway.jsonc
@@ -1,0 +1,14 @@
+// Merge these top-level default/nodes settings into config/artemis.jsonc.
+// Set ANTHROPIC_BASE_URL and ANTHROPIC_AUTH_TOKEN in .env.
+// Replace model names with aliases configured on your gateway.
+{
+  "default": {
+    "provider": "anthropic",
+    "model": "gateway-primary",
+    "fallback": {
+      "provider": "anthropic",
+      "model": "gateway-fallback"
+    }
+  },
+  "nodes": {}
+}

--- a/config/examples/multi-endpoint.jsonc
+++ b/config/examples/multi-endpoint.jsonc
@@ -1,0 +1,27 @@
+// Merge these top-level default/nodes settings into config/artemis.jsonc.
+// Replace example hosts and model aliases before use.
+{
+  "default": {
+    "provider": "openai",
+    "model": "gateway-primary",
+    "api_base": "https://primary.example.com/v1",
+    "fallback": {
+      "provider": "openai",
+      "model": "gateway-fallback",
+      "api_base": "https://backup.example.com/v1"
+    }
+  },
+  "nodes": {
+    "operator": {
+      "api_base": "https://vision.example.com/v1"
+    },
+    "outputter": {
+      "provider": "anthropic",
+      "model": "gateway-primary",
+      "fallback": {
+        "provider": "anthropic",
+        "model": "gateway-fallback"
+      }
+    }
+  }
+}

--- a/docs/llm-gateways.md
+++ b/docs/llm-gateways.md
@@ -1,0 +1,63 @@
+# LLM gateways and per-node endpoints
+
+The `provider` selects the API protocol. The `model` can be a route alias
+configured on a compatible gateway. Keep credentials in `.env` or the MCP
+server environment, and restart Artemis after changing environment settings.
+
+## Anthropic-compatible gateway with Bearer authentication
+
+Set these values in `.env`, replacing the example host and token:
+
+```dotenv
+ANTHROPIC_BASE_URL=https://gateway.example.com
+ANTHROPIC_AUTH_TOKEN=your_gateway_token_here
+```
+
+Merge the top-level `default` and `nodes` settings from
+[`anthropic-gateway.jsonc`](../config/examples/anthropic-gateway.jsonc) into
+`config/artemis.jsonc`. Retain your other application settings and replace the
+model aliases with routes available on your gateway.
+
+`ANTHROPIC_AUTH_TOKEN` sends `Authorization: Bearer ...` without an `x-api-key`
+header. It takes precedence over the global `ANTHROPIC_API_KEY`. For the
+official API with API-key authentication, leave the token and base URL unset
+and configure `ANTHROPIC_API_KEY`. An explicit SDK `ModelEndpoint.api_key`
+takes precedence over the global token.
+
+## Different endpoints for different nodes
+
+[`multi-endpoint.jsonc`](../config/examples/multi-endpoint.jsonc) demonstrates:
+
+- The default OpenAI-compatible model uses `primary.example.com`.
+- Its fallback uses `backup.example.com`.
+- The operator uses `vision.example.com` and keeps the default fallback.
+- The outputter switches to Anthropic for both primary and fallback. It drops
+  the inherited OpenAI URLs and uses `ANTHROPIC_BASE_URL` from `.env`.
+
+Configure `OPENAI_API_KEY` for the OpenAI-compatible endpoints and the
+Anthropic variables above for the outputter. These examples use one shared
+credential per provider; each server using that provider must accept it.
+Per-node URLs do not provide separate credentials or authentication modes.
+
+For OpenAI and Anthropic, URL precedence is:
+`api_base` on the node → provider environment/settings URL → provider default.
+OpenAI-compatible base URLs normally include `/v1`; the Anthropic SDK appends
+`/v1/messages`, so its base URL should omit `/v1`. Gateway path prefixes are
+preserved, for example `https://gateway.example.com/anthropic`.
+
+Changing only a model preserves its inherited URL. Changing provider removes
+an inherited URL unless the override explicitly supplies `api_base`. The same
+rule applies to fallbacks and SDK profile overrides. `api_base: null` clears
+the inherited URL and falls back to environment/settings; it does not bypass
+a configured global gateway. To choose the official service explicitly, set
+its full base URL and ensure the provider credential is valid there.
+
+The examples above use the unified `default`/`nodes` format. SDK
+`AgentProfile(from_file=...)` files instead contain expanded node overrides, such as
+`{"planner": {"provider": "openai", "model": "gateway-primary"}}`.
+
+`mobile_diagnose(verify_credentials=true)` checks the configured global
+Anthropic credential at `ANTHROPIC_BASE_URL` with its selected authentication
+method. It does not validate every per-node `api_base`. The credential check
+uses `/v1/models`; a gateway exposing only `/v1/messages` may reject this probe
+even when inference works.

--- a/mcp_server/tools/diagnose.py
+++ b/mcp_server/tools/diagnose.py
@@ -376,15 +376,19 @@ async def _verify_credentials(cred_result: ProbeResult | None) -> list[dict[str,
         return []
     metadata = cred_result.metadata
     api_keys = metadata.get("api_keys") or {}
-    targets: list[tuple[str, str, str]] = []
+    targets: list[tuple[str, str, str, dict[str, Any]]] = []
     for entry in metadata.get("providers") or []:
         provider = str(entry.get("provider") or "").strip()
         raw_key = entry.get("raw_key") or api_keys.get(provider) or ""
         if not provider or not raw_key:
             continue
-        targets.append((provider, str(entry.get("label") or provider), str(raw_key)))
+        options: dict[str, Any] = {}
+        if provider in ("anthropic", "claude"):
+            options["base_url"] = entry.get("base_url")
+            options["auth_mode"] = entry.get("auth_mode", "api_key")
+        targets.append((provider, str(entry.get("label") or provider), str(raw_key), options))
     if api_keys.get("ocr"):
-        targets.append(("ocr", "Vision OCR", str(api_keys["ocr"])))
+        targets.append(("ocr", "Vision OCR", str(api_keys["ocr"]), {}))
     if not targets:
         return []
 
@@ -397,13 +401,15 @@ async def _verify_credentials(cred_result: ProbeResult | None) -> list[dict[str,
                 timeout=CREDENTIAL_CHECK_TIMEOUT_SECONDS,
             )
             if provider in _ENDPOINT_PROVIDERS
-            else validate_api_key(provider, key, timeout=CREDENTIAL_CHECK_TIMEOUT_SECONDS)
-            for provider, _label, key in targets
+            else validate_api_key(
+                provider, key, timeout=CREDENTIAL_CHECK_TIMEOUT_SECONDS, **options
+            )
+            for provider, _label, key, options in targets
         ),
         return_exceptions=True,
     )
     verified: list[dict[str, Any]] = []
-    for (provider, label, key), outcome in zip(targets, outcomes):
+    for (provider, label, key, _options), outcome in zip(targets, outcomes):
         if isinstance(outcome, BaseException):
             valid, message = False, f"verification raised {outcome.__class__.__name__}: {outcome}"
         else:

--- a/tests/unit/test_anthropic_gateway.py
+++ b/tests/unit/test_anthropic_gateway.py
@@ -1,0 +1,216 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Gateway regressions against real SDK requests, with all HTTP sends intercepted."""
+
+import os
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import httpx
+from pydantic import SecretStr
+import pytest
+
+from artemis.config import llm as llm_config
+from artemis.config.settings import Settings
+from artemis.core.diagnostics.probes import credentials_probe
+from artemis.llm import router
+from artemis.llm.router import ModelEndpoint, ModelFactory
+from mcp_server.tools import diagnose
+
+TOKEN = "test-gateway-token-123456"
+API_KEY = "test-official-key-123456"
+BASE_URL = "https://gateway.example.test/anthropic"
+
+
+@pytest.fixture(autouse=True)
+def isolated_settings(monkeypatch):
+    # Do not read the developer's .env, enable tracing, or reuse cached clients.
+    with patch.dict(os.environ, {}, clear=True):
+        settings = Settings(_env_file=None)
+        for module in (router, llm_config, credentials_probe):
+            monkeypatch.setattr(module, "settings", settings)
+        monkeypatch.setattr(ModelFactory, "_cache", {})
+        yield settings
+
+
+@pytest.fixture
+def http_stub(monkeypatch):
+    state = SimpleNamespace(requests=[], status=200, error="")
+
+    def respond(request):
+        state.requests.append(request)
+        if state.status != 200:
+            body = {"error": {"message": state.error}}
+        elif request.method == "GET":
+            body = {"data": []}
+        else:
+            body = {
+                "id": "msg_test",
+                "type": "message",
+                "role": "assistant",
+                "model": "gateway-model",
+                "content": [{"type": "text", "text": "gateway reply"}],
+                "stop_reason": "end_turn",
+                "stop_sequence": None,
+                "usage": {"input_tokens": 1, "output_tokens": 2},
+            }
+        return httpx.Response(state.status, request=request, json=body)
+
+    def send(client, request, **kwargs):
+        return respond(request)
+
+    async def asend(client, request, **kwargs):
+        return respond(request)
+
+    monkeypatch.setattr(httpx.Client, "send", send)
+    monkeypatch.setattr(httpx.AsyncClient, "send", asend)
+    return state
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("async_call", [False, True], ids=["sync", "async"])
+@pytest.mark.parametrize(
+    "auth_case", ["settings-token", "env-token", "both-credentials", "explicit-key", "api-key"]
+)
+async def test_requests_use_exactly_the_selected_credential(
+    isolated_settings, monkeypatch, http_stub, async_call, auth_case
+):
+    if auth_case in ("both-credentials", "explicit-key", "api-key"):
+        isolated_settings.ANTHROPIC_API_KEY = SecretStr(API_KEY)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", API_KEY)
+    if auth_case != "api-key":
+        monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", TOKEN)
+        if auth_case != "env-token":
+            isolated_settings.ANTHROPIC_AUTH_TOKEN = SecretStr(TOKEN)
+            monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "lower-priority-env-token")
+
+    explicit_key = "test-scoped-key" if auth_case == "explicit-key" else None
+    model = ModelFactory.create_model(
+        ModelEndpoint(
+            provider="anthropic",
+            model_name="gateway-model",
+            api_base=BASE_URL,
+            api_key=explicit_key,
+        )
+    )
+    result = await model.ainvoke("ping") if async_call else model.invoke("ping")
+
+    assert result.content == "gateway reply"
+    assert len(http_stub.requests) == 1
+    request = http_stub.requests[0]
+    assert str(request.url) == f"{BASE_URL}/v1/messages"
+    if auth_case in ("explicit-key", "api-key"):
+        assert request.headers["x-api-key"] == (explicit_key or API_KEY)
+        assert "authorization" not in request.headers
+    else:
+        assert request.headers["authorization"] == f"Bearer {TOKEN}"
+        assert "x-api-key" not in request.headers  # Empty headers are also forbidden.
+    assert TOKEN not in request.content.decode()
+    assert TOKEN not in repr(model)
+    assert TOKEN not in str(model.model_dump())
+    assert TOKEN not in str(model.to_json())
+
+
+@pytest.mark.parametrize(
+    ("endpoint_base", "settings_base", "env_base", "expected"),
+    [
+        (BASE_URL, "https://settings.test", "https://env.test", BASE_URL),
+        (None, BASE_URL, "https://env.test", BASE_URL),
+        (None, None, BASE_URL, BASE_URL),
+        (None, None, None, "https://api.anthropic.com"),
+    ],
+)
+def test_anthropic_base_url_precedence(
+    isolated_settings, monkeypatch, http_stub, endpoint_base, settings_base, env_base, expected
+):
+    isolated_settings.ANTHROPIC_AUTH_TOKEN = SecretStr(TOKEN)
+    isolated_settings.ANTHROPIC_BASE_URL = settings_base
+    if env_base:
+        monkeypatch.setenv("ANTHROPIC_BASE_URL", env_base)
+    model = ModelFactory.create_model(
+        ModelEndpoint(provider="anthropic", model_name="gateway-model", api_base=endpoint_base)
+    )
+    model.invoke("ping")
+    assert str(http_stub.requests[0].url) == f"{expected}/v1/messages"
+
+
+@pytest.mark.parametrize("token_source", ["settings", "env"])
+def test_token_alone_satisfies_startup_validation(isolated_settings, monkeypatch, token_source):
+    if token_source == "settings":
+        isolated_settings.ANTHROPIC_AUTH_TOKEN = SecretStr(TOKEN)
+    else:
+        monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", TOKEN)
+    llm_config.LLM(provider="anthropic", model="gateway-model").validate_provider("planner")
+
+
+@pytest.mark.parametrize("placeholder", ["", "your_gateway_token_here", "<token>", "null"])
+def test_placeholder_tokens_are_not_revived_from_env(isolated_settings, monkeypatch, placeholder):
+    monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", placeholder)
+    settings = Settings(_env_file=None)
+    monkeypatch.setattr(llm_config, "settings", settings)
+    assert settings.ANTHROPIC_AUTH_TOKEN is None or not placeholder
+    assert settings.get_anthropic_auth_token() is None
+    with pytest.raises(Exception, match="requires ANTHROPIC_API_KEY"):
+        llm_config.LLM(provider="anthropic", model="gateway-model").validate_provider("planner")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "auth_case", ["settings-token", "env-token", "both-credentials", "api-key"]
+)
+async def test_diagnostic_probe_preserves_destination_and_auth(
+    isolated_settings, monkeypatch, http_stub, auth_case
+):
+    if auth_case in ("both-credentials", "api-key"):
+        isolated_settings.ANTHROPIC_API_KEY = SecretStr(API_KEY)
+    if auth_case == "env-token":
+        monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", TOKEN)
+        monkeypatch.setenv("ANTHROPIC_BASE_URL", BASE_URL)
+    else:
+        isolated_settings.ANTHROPIC_BASE_URL = f"{BASE_URL}/"
+        if auth_case != "api-key":
+            isolated_settings.ANTHROPIC_AUTH_TOKEN = SecretStr(TOKEN)
+
+    probe = await credentials_probe.LLMCredentialsProbe().probe()
+    result = await diagnose._verify_credentials(probe)
+
+    assert len(result) == 1
+    assert result[0]["valid"] is True
+    assert len(http_stub.requests) == 1
+    request = http_stub.requests[0]
+    assert str(request.url) == f"{BASE_URL}/v1/models"
+    if auth_case == "api-key":
+        assert request.headers["x-api-key"] == API_KEY
+        assert "authorization" not in request.headers
+    else:
+        assert request.headers["authorization"] == f"Bearer {TOKEN}"
+        assert "x-api-key" not in request.headers
+    assert TOKEN not in str(result)
+    assert TOKEN not in str(diagnose._scrub(probe.metadata))
+
+
+@pytest.mark.asyncio
+async def test_diagnostic_failure_redacts_gateway_token(isolated_settings, http_stub):
+    isolated_settings.ANTHROPIC_AUTH_TOKEN = SecretStr(TOKEN)
+    isolated_settings.ANTHROPIC_BASE_URL = BASE_URL
+    http_stub.status = 401
+    http_stub.error = f"Rejected credential {TOKEN}"
+    result = await diagnose._verify_credentials(
+        await credentials_probe.LLMCredentialsProbe().probe()
+    )
+    assert result[0]["valid"] is False
+    assert "401" in result[0]["message"]
+    assert TOKEN not in str(result)
+    assert "***" in result[0]["message"]

--- a/tests/unit/test_config_package.py
+++ b/tests/unit/test_config_package.py
@@ -148,11 +148,16 @@ def test_placeholder_api_key_filtering(monkeypatch):
     assert placeholder_settings.get_api_key("ocr") is None
 
 
-def test_llm_config_parsing_and_merging():
+def test_llm_config_parsing_and_merging(monkeypatch):
     """Test LLMConfig parsing, agent querying, and deep merging."""
+    from artemis.config import llm as llm_config
+
+    # Use a shipped example rather than the developer's active configuration.
+    example = Path(__file__).resolve().parents[2] / "config/examples/anthropic-gateway.jsonc"
+    monkeypatch.setattr(llm_config, "get_config_path", lambda *args: example)
     llm_cfg = get_default_llm_config()
     assert isinstance(llm_cfg, LLMConfig)
-    assert llm_cfg.planner.provider in ("google", "openai", "openrouter", "xai", "vertexai")
+    assert llm_cfg.planner.provider == "anthropic"
     assert llm_cfg.get_agent("planner") is not None
     assert llm_cfg.get_utils("hopper") is not None
 

--- a/tests/unit/test_jsonc.py
+++ b/tests/unit/test_jsonc.py
@@ -1,0 +1,47 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from io import StringIO
+import json
+
+import pytest
+
+from artemis.utils.file import load_jsonc, strip_json_comments
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "https://gateway.example.test/v1",
+        "https://gateway.example.test/*route*/models",
+        'a quoted "value" with // and /* inside the string',
+        'backslash \\ followed by a quote " and // literal',
+    ],
+)
+def test_comments_do_not_corrupt_json_strings(value):
+    document = (
+        '// Leading comment with "quotes"\r\n'
+        '{ /* block comment\n across lines */ "value": '
+        + json.dumps(value)
+        + ', // Inline comment\n "limit": 1 /* trailing comment */ }'
+    )
+    assert load_jsonc(StringIO(document)) == {"value": value, "limit": 1}
+    stripped = strip_json_comments(document)
+    assert len(stripped) == len(document)
+    assert stripped.count("\n") == document.count("\n")
+
+
+def test_comments_do_not_join_separate_number_tokens():
+    with pytest.raises(json.JSONDecodeError):
+        load_jsonc(StringIO('{"limit": 1/* not part of the number */2}'))

--- a/tests/unit/test_llm_endpoint_config.py
+++ b/tests/unit/test_llm_endpoint_config.py
@@ -1,0 +1,193 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Per-endpoint configuration regressions, including the shipped JSONC examples."""
+
+from copy import deepcopy
+import json
+import os
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from pydantic import SecretStr
+import pytest
+
+from artemis.config import llm as llm_config
+from artemis.config.settings import Settings
+from artemis.llm import router
+from artemis.services.llm import _resolve_endpoint
+
+EXAMPLES = Path(__file__).resolve().parents[2] / "config" / "examples"
+PRIMARY = "https://primary.example.test"
+BACKUP = "https://backup.example.test"
+
+
+@pytest.fixture
+def base_config():
+    return {
+        "default": {
+            "provider": "anthropic",
+            "model": "primary-model",
+            "api_base": PRIMARY,
+            "fallback": {
+                "provider": "anthropic",
+                "model": "backup-model",
+                "api_base": BACKUP,
+            },
+        }
+    }
+
+
+@pytest.mark.parametrize("load_path", ["unified", "deep-merge", "profile-file"])
+@pytest.mark.parametrize("node,is_utils", [("planner", False), ("outputter", True)])
+@pytest.mark.parametrize(
+    "override,expected_primary,expected_fallback",
+    [
+        ({"model": "another-model"}, PRIMARY, BACKUP),
+        ({"provider": "openai"}, None, BACKUP),
+        ({"fallback": {"provider": "openai"}}, PRIMARY, None),
+        ({"provider": "openai", "fallback": {"provider": "openai"}}, None, None),
+        (
+            {
+                "provider": "openai",
+                "api_base": "https://explicit.example.test/v1",
+                "fallback": {"provider": "openai", "api_base": "https://fallback.example.test/v1"},
+            },
+            "https://explicit.example.test/v1",
+            "https://fallback.example.test/v1",
+        ),
+        ({"api_base": None, "fallback": {"api_base": None}}, None, None),
+    ],
+    ids=[
+        "model-only",
+        "primary-provider",
+        "fallback-provider",
+        "both-providers",
+        "explicit-urls",
+        "explicit-null",
+    ],
+)
+def test_url_inheritance_across_loading_paths(
+    base_config,
+    monkeypatch,
+    tmp_path,
+    load_path,
+    node,
+    is_utils,
+    override,
+    expected_primary,
+    expected_fallback,
+):
+    original = deepcopy(base_config)
+    base = llm_config.LLMConfig.model_validate(llm_config._expand_default_into_nodes(base_config))
+    original_model = base.model_dump()
+    expanded_override = {"utils": {node: override}} if is_utils else {node: override}
+    if load_path == "unified":
+        config = llm_config.LLMConfig.model_validate(
+            llm_config._expand_default_into_nodes({**base_config, "nodes": {node: override}})
+        )
+    elif load_path == "deep-merge":
+        config = llm_config.deep_merge_llm_config(base, expanded_override)
+    else:
+        from artemis.sdk.types.task import AgentProfile
+
+        monkeypatch.setattr(llm_config, "get_default_llm_config", lambda: base)
+        path = tmp_path / "profile.json"
+        path.write_text(json.dumps(expanded_override), encoding="utf-8")
+        config = AgentProfile(name="gateway", from_file=str(path)).llm_config
+
+    context = SimpleNamespace(llm_config=config)
+    primary = _resolve_endpoint(context, node, is_utils=is_utils)
+    fallback = _resolve_endpoint(context, node, is_utils=is_utils, use_fallback=True)
+    assert primary.api_base == expected_primary
+    assert fallback.api_base == expected_fallback
+    assert primary.provider.value == override.get("provider", "anthropic")
+    assert fallback.provider.value == override.get("fallback", {}).get("provider", "anthropic")
+    assert config.operator.api_base == PRIMARY  # Sibling nodes must not change.
+    assert config.operator.fallback.api_base == BACKUP
+    assert base_config == original
+    assert base.model_dump() == original_model
+
+
+def test_resolved_urls_reach_openai_clients_and_separate_cache(base_config, monkeypatch):
+    with patch.dict(os.environ, {}, clear=True):
+        monkeypatch.setattr(
+            router, "settings", Settings(_env_file=None, OPENAI_API_KEY=SecretStr("test-key"))
+        )
+        monkeypatch.setattr(router.ModelFactory, "_cache", {})
+        base_config["default"]["provider"] = "openai"
+        base_config["default"]["fallback"]["provider"] = "openai"
+        base_config["nodes"] = {"operator": {"api_base": "https://operator.example.test/v1"}}
+        config = llm_config.LLMConfig.model_validate(
+            llm_config._expand_default_into_nodes(base_config)
+        )
+        context = SimpleNamespace(llm_config=config)
+        planner = _resolve_endpoint(context, "planner")
+        operator = _resolve_endpoint(context, "operator")
+        fallback = _resolve_endpoint(context, "planner", use_fallback=True)
+        models = [router.ModelFactory.get_model(ep) for ep in (planner, operator, fallback)]
+
+        assert models[0] is router.ModelFactory.get_model(planner.model_copy())
+        assert models[0] is not models[1]  # Same model name, different server.
+        assert [str(m.root_client.base_url).rstrip("/") for m in models] == [
+            PRIMARY,
+            "https://operator.example.test/v1",
+            BACKUP,
+        ]
+
+
+@pytest.mark.parametrize(
+    "example,node,is_utils,use_fallback,provider,api_base",
+    [
+        ("anthropic-gateway.jsonc", "planner", False, False, "anthropic", None),
+        ("anthropic-gateway.jsonc", "planner", False, True, "anthropic", None),
+        (
+            "multi-endpoint.jsonc",
+            "planner",
+            False,
+            False,
+            "openai",
+            "https://primary.example.com/v1",
+        ),
+        (
+            "multi-endpoint.jsonc",
+            "operator",
+            False,
+            False,
+            "openai",
+            "https://vision.example.com/v1",
+        ),
+        (
+            "multi-endpoint.jsonc",
+            "operator",
+            False,
+            True,
+            "openai",
+            "https://backup.example.com/v1",
+        ),
+        ("multi-endpoint.jsonc", "outputter", True, False, "anthropic", None),
+        ("multi-endpoint.jsonc", "outputter", True, True, "anthropic", None),
+    ],
+)
+def test_documented_examples_parse_and_resolve(
+    monkeypatch, example, node, is_utils, use_fallback, provider, api_base
+):
+    monkeypatch.setattr(llm_config, "get_config_path", lambda *args: EXAMPLES / example)
+    config = llm_config.parse_llm_config()
+    endpoint = _resolve_endpoint(
+        SimpleNamespace(llm_config=config), node, is_utils=is_utils, use_fallback=use_fallback
+    )
+    assert endpoint.provider.value == provider
+    assert endpoint.api_base == api_base


### PR DESCRIPTION
## Why

Artemis already supports multiple LLM providers, but two common gateway setups
cannot be expressed in the JSONC configuration:

- The router's endpoint URL is not exposed, so individual nodes cannot point
  at different gateway URLs.
- Anthropic-compatible gateways that require Bearer authentication cannot be
  used at all — the existing client setup only supports `x-api-key`.

## What changed

**Per-node endpoint URLs**
- Expose `api_base` for primary and fallback models and pass it through
  endpoint resolution.
- URLs are inherited within a provider and cleared when an override switches
  provider (including SDK profile overrides).

**Anthropic Bearer gateways**
- Support `ANTHROPIC_AUTH_TOKEN` + `ANTHROPIC_BASE_URL` via a small
  LangChain/SDK adapter.
- Native Bearer authentication on both sync and async clients; `x-api-key` is
  not sent in token mode.
- Explicit endpoint API keys remain authoritative; tokens are kept out of
  model representations and serialization.

**Supporting changes**
- Credential validation and diagnostics follow the selected Anthropic auth
  mode and configured gateway URL.
- Bug fix: JSONC comment stripping no longer corrupts URLs and escaped
  strings (`//` inside string values).

Minimal configuration (`config/examples/anthropic-gateway.jsonc`):

```jsonc
// Set ANTHROPIC_BASE_URL and ANTHROPIC_AUTH_TOKEN in .env.
{
  "default": {
    "provider": "anthropic",
    "model": "gateway-primary",
    "fallback": { "provider": "anthropic", "model": "gateway-fallback" }
  }
}
```

## Testing

- `make typecheck`: 0 errors.
- `make test`: 2260 passed. The 3 failures fail identically on current
  `main` (pre-existing, in unrelated files).
- `make lint`: all touched files are clean; the 11 existing findings are in
  `playground/backend_manager/` and present on `main` as well.
- New regression coverage for Bearer authentication, URL precedence and
  inheritance, cache isolation, and JSONC parsing, plus configuration
  examples and `docs/llm-gateways.md`.

Existing API-key-only configurations behave unchanged.
