### PR TITLE
Fix missing attributions to come into compliance with the Apache license

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,12 @@
+Mobile-Use
+Copyright 2025-2026 Minitap, Inc.
+
+This product includes software and architectural methodologies developed by 
+Minitap, Inc. (https://github.com/minitap-ai/mobile-use)
+
+ATTRIBUTION REQUEST:
+While the Apache 2.0 license only requires preserving copyright notices,
+we kindly request that derivative works, redistributions, or products 
+inspired by the logic/architecture of this repository include a prominent 
+attribution to "Minitap, Inc." in the documentation and "About" sections 
+of the software. This is a request, not a legal requirement.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,9 @@ description = "Autonomous AI Assistant for Mobile Automation"
 
 authors = [
     { name = "Farley Wang", email="farleyw@google.com" },
+    { name = "Pierre-Louis Favreau" },
+    { name = "Jean-Pierre Lo" },
+    { name = "Nicolas Dehandschoewercker" },
 ]
 
 requires-python = ">=3.12"


### PR DESCRIPTION
You've copied some work from Minitap's [mobile-use](https://github.com/minitap-ai/mobile-use) yet you've explicitly dropped the attributions required by the Apache license.  

This PR fixes that for you.

[More context](https://www.minitap.ai/blog/i-expected-better-from-google).